### PR TITLE
fix: resolve medium-priority IDEA inspection issues

### DIFF
--- a/flink-demo/src/test/java/io/sophiadata/flink/glm/GLMTest.java
+++ b/flink-demo/src/test/java/io/sophiadata/flink/glm/GLMTest.java
@@ -91,7 +91,7 @@ public class GLMTest {
                 while ((responseLine = br.readLine()) != null) {
                     response.append(responseLine.trim());
                 }
-                System.out.println("Response: " + response.toString());
+                System.out.println("Response: " + response);
 
                 JsonObject jsonResponse = gson.fromJson(response.toString(), JsonObject.class);
                 if (jsonResponse.has("choices")) {
@@ -113,7 +113,7 @@ public class GLMTest {
                 while ((errorLine = br.readLine()) != null) {
                     error.append(errorLine.trim());
                 }
-                System.err.println("Error Response: " + error.toString());
+                System.err.println("Error Response: " + error);
             }
         }
 
@@ -188,7 +188,7 @@ public class GLMTest {
                 while ((responseLine = br.readLine()) != null) {
                     response.append(responseLine.trim());
                 }
-                System.out.println("Response: " + response.toString());
+                System.out.println("Response: " + response);
 
                 JsonObject jsonResponse = gson.fromJson(response.toString(), JsonObject.class);
                 if (jsonResponse.has("choices")) {
@@ -210,7 +210,7 @@ public class GLMTest {
                 while ((errorLine = br.readLine()) != null) {
                     error.append(errorLine.trim());
                 }
-                System.err.println("Error Response: " + error.toString());
+                System.err.println("Error Response: " + error);
             }
         }
 

--- a/sync_database_mysql/src/test/java/io/sophiadata/flink/sync/sink/CreateMysqlLSinkTableIT.java
+++ b/sync_database_mysql/src/test/java/io/sophiadata/flink/sync/sink/CreateMysqlLSinkTableIT.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
 /**
@@ -77,9 +78,7 @@ public class CreateMysqlLSinkTableIT {
             }
             try {
                 runAgainst(
-                        url = container.getJdbcUrl(),
-                        user = container.getUsername(),
-                        pw = container.getPassword());
+                        container.getJdbcUrl(), container.getUsername(), container.getPassword());
             } finally {
                 container.stop();
             }
@@ -164,7 +163,7 @@ public class CreateMysqlLSinkTableIT {
         try {
             MysqlUtil.createTable(
                     "sink_t; DROP TABLE x", new String[] {"id"}, types, Arrays.asList("id"));
-            assertTrue("expected IllegalArgumentException", false);
+            fail("expected IllegalArgumentException");
         } catch (IllegalArgumentException expected) {
             // ok
         }

--- a/sync_database_mysql/src/test/java/io/sophiadata/flink/sync/util/MysqlUtilTest.java
+++ b/sync_database_mysql/src/test/java/io/sophiadata/flink/sync/util/MysqlUtilTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -68,8 +69,9 @@ class MysqlUtilTest {
 
         // Two TIMESTAMP columns each get the 1970 default; BIGINT must not.
         int timestampDefaultOccurrences = countOccurrences(sql, "1970-01-01 09:00:00");
-        assertTrue(
-                timestampDefaultOccurrences == 2,
+        assertEquals(
+                2,
+                timestampDefaultOccurrences,
                 "expected exactly two 1970 defaults, got "
                         + timestampDefaultOccurrences
                         + ": "


### PR DESCRIPTION
修复 IDEA inspect.sh 检出的中优先级问题：

- UnnecessaryToStringCall: 移除 GLMTest 中字符串拼接时多余的 .toString()
- UnusedAssignment: 移除 CreateMysqlLSinkTableIT 中 try 块内未使用的变量赋值
- SimplifiableAssertion: assertTrue(x==y) → assertEquals，assertTrue(false) → fail
- Convert2Diamond / Convert2Lambda: 为误报（匿名类不支持钻石操作符，FlatMapFunction 不适合 lambda），跳过

单元测试全部通过。