### PR TITLE
fix: suppress BusyWait warning in test polling pattern

### DIFF
--- a/sync_database_mysql/src/test/java/io/sophiadata/flink/sync/SchemaEvolutionIT.java
+++ b/sync_database_mysql/src/test/java/io/sophiadata/flink/sync/SchemaEvolutionIT.java
@@ -290,6 +290,7 @@ public class SchemaEvolutionIT {
         return DriverManager.getConnection(sinkUrl, "root", "root");
     }
 
+    @SuppressWarnings("BusyWait")
     private void waitForSinkRowCount(String table, int expected, int timeoutSeconds)
             throws Exception {
         long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds);


### PR DESCRIPTION
SchemaEvolutionIT.waitForSinkRowCount 使用 Thread.sleep 的 deadline 轮询模式是标准的集成测试写法，不是真正的忙等待。抑制 IDEA 警告。

其余 98 个 unused 问题全部为误报（Flink 序列化/State 机制导致 IDEA 静态分析检测不到字段使用，教程代码入口点无法被静态分析到达）。