### PR TITLE
fix: remove dead documentation links

### DIFF
--- a/DOCKER_GUIDE.md
+++ b/DOCKER_GUIDE.md
@@ -337,5 +337,5 @@ flink-jobmanager:
 
 - [Docker Compose 官方文档](https://docs.docker.com/compose/)
 - [Flink 官方文档](https://nightlies.apache.org/flink/flink-docs-release-1.20/)
-- [MySQL CDC 连接器](https://nightlies.apache.org/flink/flink-cdc-docs-release-3.6/docs/connectors/mysql-cdc/)
-- [Flink 性能调优](https://nightlies.apache.org/flink/flink-docs-release-1.20/docs/ops/performance_tuning/)
+- [Flink CDC 官方文档](https://nightlies.apache.org/flink/flink-cdc-docs-release-3.6/)
+- [Flink 性能调优](https://nightlies.apache.org/flink/flink-docs-release-1.20/docs/dev/table/tuning/)

--- a/DOCKER_TEST_GUIDE.md
+++ b/DOCKER_TEST_GUIDE.md
@@ -222,5 +222,4 @@ SHOW STATUS LIKE 'Com_insert%';
 ## 📚 相关文档
 
 - [Flink CDC 官方文档](https://nightlies.apache.org/flink/flink-cdc-docs-release-3.6/)
-- [MySQL CDC 配置说明](https://nightlies.apache.org/flink/flink-cdc-docs-release-3.6/docs/connectors/mysql-cdc/)
-- [Flink 性能调优](https://nightlies.apache.org/flink/flink-docs-release-1.20/docs/ops/performance_tuning/)
+- [Flink 性能调优](https://nightlies.apache.org/flink/flink-docs-release-1.20/docs/dev/table/tuning/)

--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ MySQL (Source) ──CDC──> Flink (sync_database_mysql) ──JDBC──> My
 - [快速开始](DOCKER_TEST_GUIDE.md) - Docker 一键测试指南
 - [开发指南](docs/DEVELOPMENT.md) - 本地开发流程
 - [工程化文档](docs/reliability/) - CI/CD 和质量保证
-- [API 文档](docs/api/) - 核心类和接口说明
 - [Paimon 同步](flink-paimon-demo/) - MySQL → Paimon 数据湖同步示例
 
 ## 🎯 核心特性


### PR DESCRIPTION
Remove broken links:
- README.md: docs/api/ (directory doesn't exist)
- DOCKER_GUIDE.md: MySQL CDC connector link (404), performance tuning URL
- DOCKER_TEST_GUIDE.md: broken MySQL CDC link, performance tuning URL