### PR TITLE
feat: add global shade configuration to root pom

### DIFF
--- a/flink-function/pom.xml
+++ b/flink-function/pom.xml
@@ -43,40 +43,21 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>${maven-shade-plugin.version}</version>
+                <configuration>
+                    <artifactSet>
+                        <excludes>
+                            <exclude>com.google.code.findbugs:jsr305</exclude>
+                            <exclude>org.slf4j:*</exclude>
+                            <exclude>log4j:*</exclude>
+                        </excludes>
+                    </artifactSet>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>
                             <goal>shade</goal>
                         </goals>
                         <phase>package</phase>
-                        <configuration>
-                            <artifactSet>
-                                <excludes>
-                                    <exclude>com.google.code.findbugs:jsr305</exclude>
-                                    <exclude>org.slf4j:*</exclude>
-                                    <exclude>log4j:*</exclude>
-                                </excludes>
-                            </artifactSet>
-                            
-                            <filters>
-                                <filter>
-                                    <!-- Do not copy the signatures in the META-INF folder.
-                                    Otherwise, this might cause SecurityExceptions when using the JAR. -->
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/*.SF</exclude>
-                                        <exclude>META-INF/*.DSA</exclude>
-                                        <exclude>META-INF/*.RSA</exclude>
-                                    </excludes>
-                                </filter>
-                            </filters>
-                            <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer">
-                                    <!--                                    <mainClass></mainClass>-->
-                                </transformer>
-                            </transformers>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/flink-paimon-demo/pom.xml
+++ b/flink-paimon-demo/pom.xml
@@ -165,68 +165,59 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>${maven-shade-plugin.version}</version>
+                <configuration>
+                    <artifactSet>
+                        <excludes>
+                            <!--
+                                CDC shaded uber jars bundle org.apache.kafka.connect.* relocated
+                                to org.apache.flink.cdc.connectors.shaded.* When this uber
+                                jar is consumed as a library (e.g. by e2e-tests), the shaded
+                                classes override the non-shaded ones from
+                                flink-connector-debezium / flink-connector-mysql-cdc and
+                                cause AbstractMethodError / NoSuchMethodError at runtime.
+                            -->
+                            <exclude>org.apache.flink:flink-sql-connector-mysql-cdc</exclude>
+                            <exclude>org.apache.flink:flink-sql-connector-mongodb-cdc</exclude>
+                            <exclude>org.apache.flink:flink-cdc-pipeline-connector-mysql</exclude>
+                            <exclude>org.apache.flink:flink-cdc-pipeline-connector-paimon</exclude>
+                            <exclude>org.apache.flink:flink-cdc-pipeline-connectors</exclude>
+                            <exclude>org.apache.flink:flink-cdc-source-connectors</exclude>
+                            <exclude>org.apache.flink:flink-cdc-connect</exclude>
+                            <exclude>org.apache.flink:flink-cdc-composer</exclude>
+                            <exclude>org.apache.flink:flink-shaded-jackson</exclude>
+                        </excludes>
+                    </artifactSet>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <!--
+                                    CDC connector internals: these classes come from multiple
+                                    CDC artifacts that may have inconsistent versions. When this
+                                    uber jar is consumed as a library (e.g. by e2e-tests), the
+                                    bundled copies override the classes that downstream modules
+                                    pull in transitively, causing AbstractMethodError /
+                                    NoSuchMethodError at runtime. sync_database_mysql declares
+                                    its own flink-connector-mysql-cdc dependency directly, so
+                                    all CDC classes needed at runtime come from there.
+                                -->
+                                <exclude>org/apache/flink/cdc/**</exclude>
+                                <exclude>io/debezium/**</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <mainClass>io.sophiadata.flink.paimon.mysql.MySqlToPaimonPipeline</mainClass>
+                        </transformer>
+                    </transformers>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>
                             <goal>shade</goal>
                         </goals>
                         <phase>package</phase>
-                        <configuration>
-                            <artifactSet>
-                                <excludes>
-                                    <exclude>org.apache.flink:flink-shaded-force-shading</exclude>
-                                    <exclude>com.google.code.findbugs:jsr305</exclude>
-                                    <exclude>org.slf4j:*</exclude>
-                                    <exclude>org.apache.logging.log4j:*</exclude>
-                                    <exclude>org.apache.flink:flink-shaded-jackson</exclude>
-                                    <!-- CDC shaded uber jars bundle org.apache.kafka.connect.* relocated
-                                             to org.apache.flink.cdc.connectors.shaded.* When this uber
-                                             jar is consumed as a library (e.g. by e2e-tests), the shaded
-                                             classes override the non-shaded ones from
-                                             flink-connector-debezium / flink-connector-mysql-cdc and
-                                             cause AbstractMethodError / NoSuchMethodError at runtime. -->
-                                    <exclude>org.apache.flink:flink-sql-connector-mysql-cdc</exclude>
-                                    <exclude>org.apache.flink:flink-sql-connector-mongodb-cdc</exclude>
-                                    <exclude>org.apache.flink:flink-cdc-pipeline-connector-mysql</exclude>
-                                    <exclude>org.apache.flink:flink-cdc-pipeline-connector-paimon</exclude>
-                                    <exclude>org.apache.flink:flink-cdc-pipeline-connectors</exclude>
-                                    <exclude>org.apache.flink:flink-cdc-source-connectors</exclude>
-                                    <exclude>org.apache.flink:flink-cdc-connect</exclude>
-                                    <exclude>org.apache.flink:flink-cdc-composer</exclude>
-                                </excludes>
-                            </artifactSet>
-                            <filters>
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/*.SF</exclude>
-                                        <exclude>META-INF/*.DSA</exclude>
-                                        <exclude>META-INF/*.RSA</exclude>
-                                        <!-- Exclude ALL CDC connector internals from the uber jar. These
-                                             classes (DebeziumDeserializationSchema, MySqlRecordEmitter,
-                                             JdbcConnectionPools, shaded Kafka Connect types, etc.) come
-                                             from multiple CDC artifacts that may have inconsistent
-                                             versions. When this uber jar is consumed as a library
-                                             (e.g. by e2e-tests), the bundled copies can override the
-                                             classes that downstream modules already pull in transitively,
-                                             causing AbstractMethodError / NoSuchMethodError at runtime.
-
-                                             FlinkSqlWDS (in sync_database_mysql) declares its own
-                                             flink-connector-mysql-cdc dependency directly, so all CDC
-                                             classes needed at runtime come from there. -->
-                                        <exclude>org/apache/flink/cdc/**</exclude>
-                                        <exclude>io/debezium/**</exclude>
-                                    </excludes>
-                                </filter>
-                            </filters>
-                            <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>io.sophiadata.flink.paimon.mysql.MySqlToPaimonPipeline</mainClass>
-                                </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                            </transformers>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
         <protobuf-java.version>3.25.5</protobuf-java.version>
         <scala-library.version>2.12.7</scala-library.version>
         <flink-shaded-jackson.version>2.13.4-16.0</flink-shaded-jackson.version>
+        <flink-shaded-force-shading.version>17.0</flink-shaded-force-shading.version>
         <mockito.version>4.6.1</mockito.version>
         <javax.el-api.version>3.0.0</javax.el-api.version>
         <org.glassfish.web.javax.el.version>2.2.4</org.glassfish.web.javax.el.version>
@@ -210,6 +211,19 @@
                 <groupId>org.apache.flink</groupId>
                 <artifactId>flink-shaded-jackson</artifactId>
                 <version>${flink-shaded-jackson.version}</version>
+            </dependency>
+            <!--
+                强制 shade 时包含此空 artifact，触发 dependency-reduced-pom 生成。
+                参考 Flink CDC root pom.xml：
+                "We need the next line to enforce all submodules to execute shade
+                and generate dependency-reduced-pom.xml, to erase all properties
+                defined in parent pom and pin them to a fixed value."
+            -->
+            <dependency>
+                <groupId>org.apache.flink</groupId>
+                <artifactId>flink-shaded-force-shading</artifactId>
+                <version>${flink-shaded-force-shading.version}</version>
+                <optional>true</optional>
             </dependency>
             <dependency>
                 <groupId>org.apache.flink</groupId>
@@ -812,6 +826,43 @@
                         <phase>verify</phase>
                     </execution>
                 </executions>
+            </plugin>
+            <!--
+                Global shade configuration: 签名文件排除 + 全局 transformer。
+
+                参考 Flink CDC（flink-cdc-parent pom.xml）：
+                - 不定义 <execution>，由子模块按需启用 shade
+                - 排除 META-INF/*.SF/DSA/RSA：签名文件导致 SecurityException
+                - ServicesResourceTransformer：合并 META-INF/services，避免 SPI 覆盖
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${maven-shade-plugin.version}</version>
+                <configuration>
+                    <shadeTestJar>false</shadeTestJar>
+                    <createDependencyReducedPom>true</createDependencyReducedPom>
+                    <shadedArtifactAttached>false</shadedArtifactAttached>
+                    <filters combine.children="append">
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>module-info.class</exclude>
+                                <!--
+                                    签名文件必须排除：JAR 被 shade 后签名失效，
+                                    加载时会抛 SecurityException。
+                                -->
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                    <transformers>
+                        <!-- 合并 META-INF/services 文件，避免 SPI 被覆盖 -->
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                    </transformers>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Following Flink CDC's shade pattern:

1. **Signature exclusion** (SF/DSA/RSA) — prevents SecurityException in shaded JARs
2. **flink-shaded-force-shading** — forces dependency-reduced-pom generation to pin parent pom variables to fixed values
3. **ServicesResourceTransformer** — merges META-INF/services files (avoids SPI override when multiple JARs declare the same provider)
4. **Inline comments** — documents each pattern's purpose with Flink CDC references

Reference: Flink CDC root pom.xml shade configuration.