### PR TITLE
fix: address evaluation findings — security, type mapping, logging, tests

### DIFF
--- a/flink-demo/src/test/java/io/sophiadata/flink/glm/GLMTest.java
+++ b/flink-demo/src/test/java/io/sophiadata/flink/glm/GLMTest.java
@@ -20,6 +20,8 @@ package io.sophiadata.flink.glm;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
@@ -34,6 +36,7 @@ public class GLMTest {
     private static final String GLM_API_URL =
             "https://open.bigmodel.cn/api/paas/v4/chat/completions";
 
+    @Disabled("Requires GLM_API_KEY and GLM_MODEL_1 environment variables; calls external API")
     @Test
     public void testGLM() throws Exception {
         String apiKey = System.getenv("GLM_API_KEY");
@@ -45,7 +48,6 @@ public class GLMTest {
         }
 
         System.out.println("Testing GLM API with model: " + model);
-        System.out.println("API Key: " + apiKey.substring(0, 10) + "...");
 
         JsonObject requestBody = new JsonObject();
         requestBody.addProperty("model", model);
@@ -94,14 +96,15 @@ public class GLMTest {
                 System.out.println("Response: " + response);
 
                 JsonObject jsonResponse = gson.fromJson(response.toString(), JsonObject.class);
-                if (jsonResponse.has("choices")) {
-                    com.google.gson.JsonArray choices = jsonResponse.getAsJsonArray("choices");
-                    if (!choices.isEmpty()) {
-                        JsonObject choice = choices.get(0).getAsJsonObject();
-                        JsonObject msg = choice.getAsJsonObject("message");
-                        System.out.println("AI Response: " + msg.get("content").getAsString());
-                    }
-                }
+                Assertions.assertTrue(
+                        jsonResponse.has("choices"), "Response should contain 'choices'");
+                com.google.gson.JsonArray choices = jsonResponse.getAsJsonArray("choices");
+                Assertions.assertFalse(choices.isEmpty(), "Choices should not be empty");
+                JsonObject choice = choices.get(0).getAsJsonObject();
+                JsonObject msg = choice.getAsJsonObject("message");
+                Assertions.assertNotNull(
+                        msg.get("content"), "AI response content should not be null");
+                System.out.println("AI Response: " + msg.get("content").getAsString());
             }
         } else {
             try (BufferedReader br =
@@ -118,8 +121,10 @@ public class GLMTest {
         }
 
         connection.disconnect();
+        Assertions.assertEquals(HttpURLConnection.HTTP_OK, responseCode, "API call should succeed");
     }
 
+    @Disabled("Requires GLM_API_KEY and GLM_MODEL_* environment variables; calls external API")
     @Test
     public void testAllModels() throws Exception {
         String[] models = {
@@ -191,14 +196,15 @@ public class GLMTest {
                 System.out.println("Response: " + response);
 
                 JsonObject jsonResponse = gson.fromJson(response.toString(), JsonObject.class);
-                if (jsonResponse.has("choices")) {
-                    com.google.gson.JsonArray choices = jsonResponse.getAsJsonArray("choices");
-                    if (!choices.isEmpty()) {
-                        JsonObject choice = choices.get(0).getAsJsonObject();
-                        JsonObject msg = choice.getAsJsonObject("message");
-                        System.out.println("AI Response: " + msg.get("content").getAsString());
-                    }
-                }
+                Assertions.assertTrue(
+                        jsonResponse.has("choices"), "Response should contain 'choices'");
+                com.google.gson.JsonArray choices = jsonResponse.getAsJsonArray("choices");
+                Assertions.assertFalse(choices.isEmpty(), "Choices should not be empty");
+                JsonObject choice = choices.get(0).getAsJsonObject();
+                JsonObject msg = choice.getAsJsonObject("message");
+                Assertions.assertNotNull(
+                        msg.get("content"), "AI response content should not be null");
+                System.out.println("AI Response: " + msg.get("content").getAsString());
             }
         } else {
             try (BufferedReader br =
@@ -215,5 +221,6 @@ public class GLMTest {
         }
 
         connection.disconnect();
+        Assertions.assertEquals(HttpURLConnection.HTTP_OK, responseCode, "API call should succeed");
     }
 }

--- a/sync_database_mysql/src/main/java/io/sophiadata/flink/sync/FlinkSqlWDS.java
+++ b/sync_database_mysql/src/main/java/io/sophiadata/flink/sync/FlinkSqlWDS.java
@@ -223,7 +223,7 @@ public class FlinkSqlWDS extends BaseCode {
         try {
             evolver.processEvent((SchemaChangeEvent) event);
         } catch (Exception e) {
-            LOG.error("SchemaEvolver error: {}", e.getMessage());
+            LOG.error("SchemaEvolver error", e);
         }
         if (event instanceof CreateTableEvent) {
             handleCreateTable(

--- a/sync_database_mysql/src/main/java/io/sophiadata/flink/sync/schema/SchemaEvolver.java
+++ b/sync_database_mysql/src/main/java/io/sophiadata/flink/sync/schema/SchemaEvolver.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 
+import io.sophiadata.flink.sync.util.MysqlUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -352,36 +353,8 @@ public class SchemaEvolver implements java.io.Serializable, CheckpointedFunction
         return alterConnection;
     }
 
-    private static final java.util.Map<String, String> MYSQL_TYPE_MAP = new java.util.HashMap<>();
-
-    static {
-        MYSQL_TYPE_MAP.put("TEXT", "VARCHAR(2147483647)");
-        MYSQL_TYPE_MAP.put("BIGINT", "BIGINT");
-        MYSQL_TYPE_MAP.put("INT", "INT");
-        MYSQL_TYPE_MAP.put("TINYINT", "INT");
-        MYSQL_TYPE_MAP.put("SMALLINT", "INT");
-        MYSQL_TYPE_MAP.put("TIMESTAMP", "TIMESTAMP(6)");
-        MYSQL_TYPE_MAP.put("DATETIME", "DATETIME(6)");
-        MYSQL_TYPE_MAP.put("DATE", "DATE");
-        MYSQL_TYPE_MAP.put("TIME", "TIME");
-        MYSQL_TYPE_MAP.put("DOUBLE", "DOUBLE");
-        MYSQL_TYPE_MAP.put("FLOAT", "FLOAT");
-        MYSQL_TYPE_MAP.put("BOOLEAN", "BOOLEAN");
-        MYSQL_TYPE_MAP.put("BOOL", "BOOLEAN");
-        MYSQL_TYPE_MAP.put("BLOB", "BLOB");
-        MYSQL_TYPE_MAP.put("BINARY", "BLOB");
-        MYSQL_TYPE_MAP.put("VARBINARY", "BLOB");
-    }
-
     private String mapToMysqlType(final String cdcType) {
-        final String u = cdcType.toUpperCase();
-        if (u.contains("VARCHAR") || u.contains("CHAR")) {
-            return cdcType;
-        }
-        if (u.contains("DECIMAL")) {
-            return cdcType;
-        }
-        return MYSQL_TYPE_MAP.getOrDefault(u, "VARCHAR(2147483647)");
+        return MysqlUtil.mapType(cdcType);
     }
 
     public void shutdown() {

--- a/sync_database_mysql/src/test/java/io/sophiadata/flink/sync/CdcEventDeserializerTest.java
+++ b/sync_database_mysql/src/test/java/io/sophiadata/flink/sync/CdcEventDeserializerTest.java
@@ -1,0 +1,311 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sophiadata.flink.sync;
+
+import org.apache.flink.cdc.common.event.DataChangeEvent;
+import org.apache.flink.cdc.common.event.Event;
+import org.apache.flink.cdc.common.event.OperationType;
+import org.apache.flink.cdc.common.event.TruncateTableEvent;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CdcEventDeserializerTest {
+
+    private CdcEventDeserializer deserializer;
+
+    private static final Schema SOURCE_SCHEMA =
+            SchemaBuilder.struct()
+                    .field("db", Schema.STRING_SCHEMA)
+                    .field("table", Schema.STRING_SCHEMA)
+                    .build();
+
+    private static final Schema BEFORE_AFTER_SCHEMA =
+            SchemaBuilder.struct()
+                    .field("id", Schema.INT64_SCHEMA)
+                    .field("name", Schema.STRING_SCHEMA)
+                    .build();
+
+    private static final Schema VALUE_SCHEMA =
+            SchemaBuilder.struct()
+                    .field("op", Schema.STRING_SCHEMA)
+                    .field("source", SOURCE_SCHEMA)
+                    .field("before", BEFORE_AFTER_SCHEMA)
+                    .field("after", BEFORE_AFTER_SCHEMA)
+                    .build();
+
+    @BeforeEach
+    void setUp() {
+        deserializer = new CdcEventDeserializer();
+    }
+
+    // --- convertValue tests ---
+
+    @Test
+    void convertValue_null_returnsNull() {
+        assertNull(CdcEventDeserializer.convertValue(null));
+    }
+
+    @Test
+    void convertValue_offsetDateTime_returnsTimestamp() {
+        OffsetDateTime odt = OffsetDateTime.of(2024, 6, 15, 10, 30, 0, 0, ZoneOffset.ofHours(8));
+        Object result = CdcEventDeserializer.convertValue(odt);
+        assertTrue(result instanceof java.sql.Timestamp);
+        assertEquals(odt.toInstant(), ((java.sql.Timestamp) result).toInstant());
+    }
+
+    @Test
+    void convertValue_zonedDateTime_returnsTimestamp() {
+        ZonedDateTime zdt = ZonedDateTime.of(2024, 6, 15, 10, 30, 0, 0, ZoneOffset.UTC);
+        Object result = CdcEventDeserializer.convertValue(zdt);
+        assertTrue(result instanceof java.sql.Timestamp);
+        assertEquals(zdt.toInstant(), ((java.sql.Timestamp) result).toInstant());
+    }
+
+    @Test
+    void convertValue_instant_returnsTimestamp() {
+        Instant instant = Instant.parse("2024-06-15T10:30:00Z");
+        Object result = CdcEventDeserializer.convertValue(instant);
+        assertTrue(result instanceof java.sql.Timestamp);
+        assertEquals(instant, ((java.sql.Timestamp) result).toInstant());
+    }
+
+    @Test
+    void convertValue_localDateTime_returnsTimestamp() {
+        LocalDateTime ldt = LocalDateTime.of(2024, 6, 15, 10, 30, 0);
+        Object result = CdcEventDeserializer.convertValue(ldt);
+        assertTrue(result instanceof java.sql.Timestamp);
+        assertEquals(ldt, ((java.sql.Timestamp) result).toLocalDateTime());
+    }
+
+    @Test
+    void convertValue_utilDate_returnsTimestamp() {
+        java.util.Date date = new java.util.Date(1718450000000L);
+        Object result = CdcEventDeserializer.convertValue(date);
+        assertTrue(result instanceof java.sql.Timestamp);
+        assertEquals(date.getTime(), ((java.sql.Timestamp) result).getTime());
+    }
+
+    @Test
+    void convertValue_isoStringWithT_returnsTimestamp() {
+        Object result = CdcEventDeserializer.convertValue("2024-06-15T10:30:00Z");
+        assertTrue(result instanceof java.sql.Timestamp);
+        assertEquals(
+                Instant.parse("2024-06-15T10:30:00Z"), ((java.sql.Timestamp) result).toInstant());
+    }
+
+    @Test
+    void convertValue_nonIsoString_returnsOriginal() {
+        String value = "hello world";
+        assertSame(value, CdcEventDeserializer.convertValue(value));
+    }
+
+    @Test
+    void convertValue_number_returnsOriginal() {
+        assertEquals(42, CdcEventDeserializer.convertValue(42));
+        assertEquals(3.14, CdcEventDeserializer.convertValue(3.14));
+    }
+
+    // --- extractValues tests ---
+
+    @Test
+    void extractValues_null_returnsNull() {
+        assertNull(CdcEventDeserializer.extractValues(null));
+    }
+
+    @Test
+    void extractValues_extractsAllFields() {
+        Schema schema =
+                SchemaBuilder.struct()
+                        .field("id", Schema.INT64_SCHEMA)
+                        .field("name", Schema.STRING_SCHEMA)
+                        .build();
+        Struct row = new Struct(schema);
+        row.put("id", 1L);
+        row.put("name", "Alice");
+
+        Object[] values = CdcEventDeserializer.extractValues(row);
+        assertNotNull(values);
+        assertEquals(2, values.length);
+        assertEquals(1L, values[0]);
+        assertEquals("Alice", values[1]);
+    }
+
+    // --- deserialize DML events ---
+
+    @Test
+    void deserialize_insertEvent() throws Exception {
+        SourceRecord record = createDMLRecord("c", 1L, null, "Alice");
+        List<Event> events = collectEvents(record);
+
+        assertEquals(1, events.size());
+        assertTrue(events.get(0) instanceof DataChangeEvent);
+        DataChangeEvent dce = (DataChangeEvent) events.get(0);
+        assertEquals(OperationType.INSERT, dce.op());
+        assertEquals("test_table", dce.tableId().getTableName());
+    }
+
+    @Test
+    void deserialize_readEvent_alsoMapsToInsert() throws Exception {
+        SourceRecord record = createDMLRecord("r", 1L, null, "Bob");
+        List<Event> events = collectEvents(record);
+
+        assertEquals(1, events.size());
+        assertTrue(events.get(0) instanceof DataChangeEvent);
+        DataChangeEvent dce = (DataChangeEvent) events.get(0);
+        assertEquals(OperationType.INSERT, dce.op());
+    }
+
+    @Test
+    void deserialize_updateEvent() throws Exception {
+        SourceRecord record = createDMLRecord("u", 1L, "Alice", "AliceUpdated");
+        List<Event> events = collectEvents(record);
+
+        assertEquals(1, events.size());
+        assertTrue(events.get(0) instanceof DataChangeEvent);
+        DataChangeEvent dce = (DataChangeEvent) events.get(0);
+        assertEquals(OperationType.UPDATE, dce.op());
+    }
+
+    @Test
+    void deserialize_deleteEvent() throws Exception {
+        SourceRecord record = createDMLRecord("d", 1L, "Alice", null);
+        List<Event> events = collectEvents(record);
+
+        assertEquals(1, events.size());
+        assertTrue(events.get(0) instanceof DataChangeEvent);
+        DataChangeEvent dce = (DataChangeEvent) events.get(0);
+        assertEquals(OperationType.DELETE, dce.op());
+    }
+
+    @Test
+    void deserialize_truncateEvent() throws Exception {
+        SourceRecord record = createDMLRecord("t", null, null, null);
+        List<Event> events = collectEvents(record);
+
+        assertEquals(1, events.size());
+        assertTrue(events.get(0) instanceof TruncateTableEvent);
+    }
+
+    @Test
+    void deserialize_unknownOp_emitsNothing() throws Exception {
+        SourceRecord record = createDMLRecord("x", null, null, null);
+        List<Event> events = collectEvents(record);
+
+        assertEquals(0, events.size());
+    }
+
+    @Test
+    void deserialize_nullRecord_emitsNothing() throws Exception {
+        List<Event> events = collectEvents(null);
+        assertEquals(0, events.size());
+    }
+
+    @Test
+    void deserialize_nullValue_emitsNothing() throws Exception {
+        SourceRecord record =
+                new SourceRecord(
+                        Collections.singletonMap("topic", "test"),
+                        Collections.singletonMap("partition", 0),
+                        "test",
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null);
+        List<Event> events = collectEvents(record);
+        assertEquals(0, events.size());
+    }
+
+    // --- helpers ---
+
+    private SourceRecord createDMLRecord(
+            final String op, final Long id, final String beforeName, final String afterName) {
+        Struct source = new Struct(SOURCE_SCHEMA);
+        source.put("db", "testdb");
+        source.put("table", "test_table");
+
+        Struct value = new Struct(VALUE_SCHEMA);
+        value.put("op", op);
+        value.put("source", source);
+
+        if (beforeName != null) {
+            Struct before = new Struct(BEFORE_AFTER_SCHEMA);
+            before.put("id", id);
+            before.put("name", beforeName);
+            value.put("before", before);
+        }
+
+        if (afterName != null) {
+            Struct after = new Struct(BEFORE_AFTER_SCHEMA);
+            after.put("id", id);
+            after.put("name", afterName);
+            value.put("after", after);
+        }
+
+        return new SourceRecord(
+                Collections.singletonMap("topic", "test"),
+                Collections.singletonMap("partition", 0),
+                "test",
+                null,
+                null,
+                null,
+                VALUE_SCHEMA,
+                value,
+                null,
+                null);
+    }
+
+    private List<Event> collectEvents(final SourceRecord record) throws Exception {
+        List<Event> events = new ArrayList<>();
+        deserializer.deserialize(
+                record,
+                new org.apache.flink.util.Collector<Event>() {
+                    @Override
+                    public void collect(Event event) {
+                        events.add(event);
+                    }
+
+                    @Override
+                    public void close() {}
+                });
+        return events;
+    }
+}

--- a/sync_database_mysql/src/test/java/io/sophiadata/flink/sync/schema/SchemaEvolverTest.java
+++ b/sync_database_mysql/src/test/java/io/sophiadata/flink/sync/schema/SchemaEvolverTest.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sophiadata.flink.sync.schema;
+
+import org.apache.flink.cdc.common.event.AddColumnEvent;
+import org.apache.flink.cdc.common.event.CreateTableEvent;
+import org.apache.flink.cdc.common.event.DropColumnEvent;
+import org.apache.flink.cdc.common.event.DropTableEvent;
+import org.apache.flink.cdc.common.event.RenameColumnEvent;
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.event.TruncateTableEvent;
+import org.apache.flink.cdc.common.schema.Column;
+import org.apache.flink.cdc.common.schema.Schema;
+import org.apache.flink.cdc.common.types.DataTypes;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class SchemaEvolverTest {
+
+    // --- mapToMysqlType (delegates to MysqlUtil.mapType) ---
+
+    @Test
+    void mapToMysqlType_text_returnsVarchar() {
+        SchemaEvolver evolver = createEvolver();
+        assertEquals("VARCHAR(1024)", invokeMapToMysqlType(evolver, "TEXT"));
+    }
+
+    @Test
+    void mapToMysqlType_bigint_returnsBigint() {
+        SchemaEvolver evolver = createEvolver();
+        assertEquals("BIGINT", invokeMapToMysqlType(evolver, "BIGINT"));
+    }
+
+    @Test
+    void mapToMysqlType_int_returnsInt() {
+        SchemaEvolver evolver = createEvolver();
+        assertEquals("INT", invokeMapToMysqlType(evolver, "INT"));
+    }
+
+    @Test
+    void mapToMysqlType_boolean_returnsTinyInt() {
+        SchemaEvolver evolver = createEvolver();
+        assertEquals("TINYINT(1)", invokeMapToMysqlType(evolver, "BOOLEAN"));
+    }
+
+    @Test
+    void mapToMysqlType_timestamp_returnsTimestamp6() {
+        SchemaEvolver evolver = createEvolver();
+        assertEquals("TIMESTAMP(6)", invokeMapToMysqlType(evolver, "TIMESTAMP"));
+    }
+
+    @Test
+    void mapToMysqlType_datetime_returnsDatetime6() {
+        SchemaEvolver evolver = createEvolver();
+        assertEquals("DATETIME(6)", invokeMapToMysqlType(evolver, "DATETIME"));
+    }
+
+    @Test
+    void mapToMysqlType_varcharWithPrecision_preservesPrecision() {
+        SchemaEvolver evolver = createEvolver();
+        assertEquals("VARCHAR(100)", invokeMapToMysqlType(evolver, "VARCHAR(100)"));
+    }
+
+    @Test
+    void mapToMysqlType_decimalWithPrecision_preservesPrecision() {
+        SchemaEvolver evolver = createEvolver();
+        assertEquals("DECIMAL(10,2)", invokeMapToMysqlType(evolver, "DECIMAL(10,2)"));
+    }
+
+    @Test
+    void mapToMysqlType_unknownType_returnsVarchar1024() {
+        SchemaEvolver evolver = createEvolver();
+        assertEquals("VARCHAR(1024)", invokeMapToMysqlType(evolver, "UNKNOWN_TYPE"));
+    }
+
+    @Test
+    void mapToMysqlType_caseInsensitive() {
+        SchemaEvolver evolver = createEvolver();
+        assertEquals("BIGINT", invokeMapToMysqlType(evolver, "bigint"));
+        assertEquals("INT", invokeMapToMysqlType(evolver, "int"));
+    }
+
+    // --- Constructor and basic properties ---
+
+    @Test
+    void constructor_withTablePrefix() {
+        SchemaEvolver evolver =
+                new SchemaEvolver("jdbc:mysql://localhost:3306/test", "root", "pass", "sink_");
+        assertNotNull(evolver);
+    }
+
+    @Test
+    void constructor_withoutTablePrefix() {
+        SchemaEvolver evolver =
+                new SchemaEvolver("jdbc:mysql://localhost:3306/test", "root", "pass");
+        assertNotNull(evolver);
+    }
+
+    // --- processEvent dispatching ---
+
+    @Test
+    void processEvent_createTable_doesNotThrow() {
+        SchemaEvolver evolver = createEvolver();
+        CreateTableEvent event =
+                new CreateTableEvent(
+                        TableId.tableId("testdb", "test_table"),
+                        Schema.newBuilder()
+                                .column(Column.physicalColumn("id", DataTypes.BIGINT()))
+                                .column(Column.physicalColumn("name", DataTypes.VARCHAR(100)))
+                                .primaryKey(Collections.singletonList("id"))
+                                .build());
+        evolver.processEvent(event);
+    }
+
+    @Test
+    void processEvent_addColumn_doesNotThrow() {
+        SchemaEvolver evolver = createEvolver();
+        AddColumnEvent event =
+                new AddColumnEvent(
+                        TableId.tableId("testdb", "test_table"),
+                        Collections.singletonList(
+                                new AddColumnEvent.ColumnWithPosition(
+                                        Column.physicalColumn("new_col", DataTypes.INT()))));
+        evolver.processEvent(event);
+    }
+
+    @Test
+    void processEvent_dropColumn_doesNotThrow() {
+        SchemaEvolver evolver = createEvolver();
+        DropColumnEvent event =
+                new DropColumnEvent(
+                        TableId.tableId("testdb", "test_table"),
+                        Collections.singletonList("old_col"));
+        evolver.processEvent(event);
+    }
+
+    @Test
+    void processEvent_renameColumn_doesNotThrow() {
+        SchemaEvolver evolver = createEvolver();
+        Map<String, String> nameMapping = new LinkedHashMap<>();
+        nameMapping.put("old_name", "new_name");
+        RenameColumnEvent event =
+                new RenameColumnEvent(TableId.tableId("testdb", "test_table"), nameMapping);
+        evolver.processEvent(event);
+    }
+
+    @Test
+    void processEvent_dropTable_doesNotThrow() {
+        SchemaEvolver evolver = createEvolver();
+        DropTableEvent event = new DropTableEvent(TableId.tableId("testdb", "test_table"));
+        evolver.processEvent(event);
+    }
+
+    @Test
+    void processEvent_truncateTable_doesNotThrow() {
+        SchemaEvolver evolver = createEvolver();
+        TruncateTableEvent event = new TruncateTableEvent(TableId.tableId("testdb", "test_table"));
+        evolver.processEvent(event);
+    }
+
+    // --- shutdown ---
+
+    @Test
+    void shutdown_doesNotThrow() {
+        SchemaEvolver evolver = createEvolver();
+        evolver.shutdown();
+    }
+
+    // --- helpers ---
+
+    private SchemaEvolver createEvolver() {
+        return new SchemaEvolver("jdbc:mysql://localhost:3306/test", "root", "pass", "sink_");
+    }
+
+    /**
+     * Invoke the private mapToMysqlType method via reflection for unit testing. Since
+     * mapToMysqlType now delegates to MysqlUtil.mapType(), this validates the delegation.
+     */
+    private String invokeMapToMysqlType(SchemaEvolver evolver, String cdcType) {
+        try {
+            java.lang.reflect.Method method =
+                    SchemaEvolver.class.getDeclaredMethod("mapToMysqlType", String.class);
+            method.setAccessible(true);
+            return (String) method.invoke(evolver, cdcType);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to invoke mapToMysqlType", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **GLMTest 安全修复 (P0)**: 添加 `@Disabled` 防止 CI 调用外部 API，移除 API Key 泄露，添加缺失的断言
- **类型映射统一 (P0)**: `SchemaEvolver.mapToMysqlType()` 改为委托 `MysqlUtil.mapType()`，消除 `TEXT` 在不同路径映射为 `VARCHAR(2147483647)` vs `VARCHAR(1024)` 的不一致问题
- **异常日志修复 (P1)**: `FlinkSqlWDS` 中 SchemaEvolver 错误日志从 `e.getMessage()` 改为保留完整堆栈
- **核心类单元测试 (P1)**: 新增 `CdcEventDeserializerTest`（19 个测试）和 `SchemaEvolverTest`（19 个测试），覆盖 convertValue 时间转换、DML 事件反序列化、类型映射委托、事件分发等核心逻辑

## Changes

| 文件 | 变更 |
|---|---|
| `GLMTest.java` | +@Disabled, -API Key print, +Assertions |
| `SchemaEvolver.java` | 移除重复 MYSQL_TYPE_MAP，委托 MysqlUtil.mapType() |
| `FlinkSqlWDS.java` | `LOG.error("...", e.getMessage())` → `LOG.error("...", e)` |
| `CdcEventDeserializerTest.java` | 新增 19 个单元测试 |
| `SchemaEvolverTest.java` | 新增 19 个单元测试 |

## Test

```bash
# 全部 52 个单元测试通过
./mvnw test -pl sync_database_mysql -Dtest="!*IT,!*IntegrationTest,!*FlinkSqlWDSTest"

# spotless 格式检查通过
./mvnw spotless:check -pl sync_database_mysql,flink-demo
```