### PR TITLE
fix: resolve dependency version inconsistencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ tmp
 .env
 .env.*
 config.properties
+docker-config.properties
 dependency-reduced-pom.xml
 .mimocode/
 

--- a/e2e-tests/pom.xml
+++ b/e2e-tests/pom.xml
@@ -166,7 +166,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.6.1</version>
+            <version>${kafka.version}</version>
             <scope>test</scope>
         </dependency>
         

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,12 @@
                 <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>
+            <!-- CVE-2022-1471: snakeyaml -->
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>${snakeyaml.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>

--- a/sync_database_mysql/pom.xml
+++ b/sync_database_mysql/pom.xml
@@ -358,11 +358,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- CVE-2022-1471: snakeyaml 升级到 2.0 -->
+        <!-- CVE-2022-1471: snakeyaml 升级到 2.0+ (version managed in root pom) -->
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>2.0</version>
         </dependency>
         <!-- CVE-2024-25638: dnsjava 升级到 3.6.0 -->
         <dependency>


### PR DESCRIPTION
## Summary

修复项目依赖版本不一致问题：

- **snakeyaml**: 根 POM 添加 dependencyManagement 统一管理（版本 2.2），移除 sync_database_mysql 中的硬编码版本 2.0
- **kafka-clients**: e2e-tests 改用 `${kafka.version}`（4.1.2），不再硬编码 3.6.1
- **docker-config.properties**: 加入 .gitignore（含明文开发凭证）

## Changes

| 文件 | 变更 |
|---|---|
| `pom.xml` | 添加 snakeyaml 到 dependencyManagement |
| `sync_database_mysql/pom.xml` | 移除 snakeyaml 硬编码版本 |
| `e2e-tests/pom.xml` | kafka-clients 改用 `${kafka.version}` |
| `.gitignore` | 添加 docker-config.properties |

## Test

```bash
./mvnw test -pl sync_database_mysql -Dtest="!*IT,!*IntegrationTest,!*FlinkSqlWDSTest"
# 52 tests passed
```

## Note

Jackson annotations 版本 `2.21` 是正确的 — Jackson annotations 没有 `.4` 后缀的补丁版本（只有 `2.21`、`2.22` 等），而 jackson-core/databind 有 `2.21.4`。这是 Jackson 项目本身的版本策略差异。