### PR TITLE
fix: P1+P2 config cleanup — log4j, docs, docker, pre-commit, pom

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,40 +19,10 @@
 # See https://pre-commit.com/hooks.html for more hooks
 
 default_stages: [commit, push]
-default_language_version:
-  # force all python hooks to run python3
-  python: python3
 repos:
-  # Python API Hooks
-  - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
-        name: isort (python)
-  - repo: https://github.com/psf/black
-    rev: 22.3.0
-    hooks:
-      - id: black
-  - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
-    hooks:
-      - id: flake8
-        additional_dependencies: [
-          'flake8-docstrings>=1.6',
-          'flake8-black>=0.2',
-        ]
-  - repo: https://github.com/pycqa/autoflake
-    rev: v1.4
-    hooks:
-      - id: autoflake
-        args: [
-          --remove-all-unused-imports,
-          --ignore-init-module-imports,
-          --in-place
-        ]
   - repo: local
     hooks:
-      # Spotless Hooks
+      # Spotless: google-java-format AOSP + License header
       - id: spotless
         name: spotless lint
         entry: ./mvnw spotless:apply

--- a/docs/ai-context/project-structure.md
+++ b/docs/ai-context/project-structure.md
@@ -6,7 +6,7 @@
 
 ```
 Bigdata_Code_Tutorial/
-├── pom.xml                          聚合 POM（Java 11，三个 module）
+├── pom.xml                          聚合 POM（Java 11，五个 module）
 ├── CLAUDE.md                        Claude 项目指令
 ├── README.md                        项目说明
 ├── LICENSE
@@ -16,7 +16,9 @@ Bigdata_Code_Tutorial/
 │   └── ai-context/                  本目录
 ├── flink-demo/                      模块 1：DataStream/SQL/UDF 示例
 ├── sync_database_mysql/             模块 2：整库同步（核心）
-└── flink-function/                  模块 3：可复用 Flink 函数
+├── flink-function/                  模块 3：可复用 Flink 函数
+├── flink-paimon-demo/               模块 4：CDC → Paimon 数据湖同步
+└── e2e-tests/                       模块 5：端到端集成测试
 ```
 
 ## flink-demo/
@@ -28,11 +30,14 @@ flink-demo/
     ├── main/java/io/sophiadata/flink/
     │   ├── base/                    BaseCode、BaseSql 抽象
     │   ├── ddl/                     FlinkCDC DDL + Debezium 反序列化
+    │   ├── glm/                     GLM API 测试（@Disabled）
     │   ├── source/                  MockSourceFunction、App* bean、配置
+    │   │   └── utils/               ParamUtil、RandomNumString、ConfigUtil 等
     │   ├── sql/                     SQLTest 入口
     │   ├── streaming/               WordCount / Sideout / IncrementMapFunction
     │   └── udf/                     UDF 示例
     └── test/java/io/sophiadata/flink/
+        ├── glm/                     GLMTest
         └── streaming/               JUnit 5 测试
 ```
 
@@ -41,23 +46,28 @@ flink-demo/
 ```
 sync_database_mysql/
 ├── pom.xml
-├── config.properties                本地配置模板（track，运行时覆盖）
+├── config.properties                本地配置模板（运行时覆盖）
 └── src/
     ├── main/java/io/sophiadata/flink/sync/
     │   ├── FlinkSqlWDS.java         整库同步主入口
+    │   ├── CdcEventDeserializer.java  Debezium SourceRecord → Flink CDC Event
+    │   ├── CDBBatchSink.java        批量 JDBC Sink（upsert/delete）
+    │   ├── SharedSchemaState.java   静态共享 schema（绕过 Flink 序列化）
     │   ├── base/BaseCode.java
-    │   ├── common/Constants.java
-    │   ├── schema/SchemaEvolver.java   处理 CDC schema 变更（AddColumn/DropColumn/AlterColumnType/RenameColumn/DropTable/Truncate）
+    │   ├── schema/SchemaEvolver.java  处理 CDC schema 变更（CheckpointedFunction）
     │   └── util/
-    │       ├── MysqlUtil.java       JDBC、建表 SQL 生成
+    │       ├── MysqlUtil.java       JDBC、建表 SQL 生成、类型映射
     │       ├── NacosUtil.java       Nacos / 本地配置合并
     │       ├── ParameterUtil.java   ParameterTool 字段读取
     │       └── PropertiesUtil.java  Properties 解析
-    ├── main/resources/              log4j2 配置
+    ├── main/resources/              log4j 配置、config.properties
     └── test/java/io/sophiadata/flink/
         ├── cdc/                     旧 CDC 集成测试（testcontainers）
-        ├── sync/                    FlinkSqlWDSTest（新集成测试）
-        │   └── util/                JUnit 5 单元测试（MysqlUtilTest/NacosUtilTest/...）
+        ├── sync/                    单元测试
+        │   ├── CdcEventDeserializerTest.java  19 个测试
+        │   ├── FlinkSqlWDSTest.java
+        │   ├── schema/SchemaEvolverTest.java  19 个测试
+        │   └── util/                MysqlUtilTest/NacosUtilTest/ParameterUtilTest/...
         └── utils/MySqlContainer.java  testcontainers 工具
 ```
 
@@ -73,26 +83,55 @@ flink-function/
         └── SplitFunctionTest.java   JUnit 5
 ```
 
+## flink-paimon-demo/
+
+```
+flink-paimon-demo/
+├── pom.xml                          shade jar，mainClass: MySqlToPaimonPipeline
+├── docker-compose.yml               MySQL 8.4.0 + Flink 1.20
+└── src/
+    ├── main/java/io/sophiadata/flink/paimon/
+    │   ├── mongo/                   MongoDB → Paimon（DataStream + SQL）
+    │   └── mysql/                   MySQL → Paimon（DataStream + SQL）
+    └── test/java/                   MongoTypeMapperTest、MongoDocumentFlattenerTest 等
+```
+
+## e2e-tests/
+
+```
+e2e-tests/
+├── pom.xml                          仅测试，依赖前三个模块
+└── src/test/java/
+    ├── SchemaEvolutionIT.java       schema 变更端到端（Testcontainers MySQL）
+    ├── CDBBatchSinkIT.java          批量写入测试（H2）
+    ├── CreateMysqlLSinkTableIT.java sink 建表测试
+    └── paimon/mongo/                MongoDB → Paimon E2E
+```
+
 ## 关键依赖流向
 
 ```
 sync_database_mysql
   ├─ flink-connector-mysql-cdc 3.6.0-1.20 (provided)
   ├─ flink-cdc-common 3.6.0-1.20
-  ├─ flink-sql-connector-mysql-cdc 3.6.0-1.20
-  ├─ flink-connector-jdbc
-  ├─ mysql-connector-java 8.0.30
+  ├─ flink-connector-jdbc 3.3.0-1.20
+  ├─ mysql-connector-j 8.4.0
   ├─ nacos-client 2.1.2
   └─ flink-test-utils-junit (test)
 
 flink-demo
   ├─ flink-streaming-java (provided)
   ├─ flink-table-api-*
-  └─ flink-connector-kafka
+  └─ flink-connector-kafka 3.3.0-1.20
 
 flink-function
   ├─ flink-table-api-java-bridge
   └─ flink-table-planner
+
+flink-paimon-demo
+  ├─ flink-cdc-connect-mysql
+  ├─ flink-paimon
+  └─ flink-connector-mongodb (for mongo examples)
 ```
 
 ## 修改模块结构时的 checklist

--- a/flink-demo/src/main/resources/log4j.properties
+++ b/flink-demo/src/main/resources/log4j.properties
@@ -16,25 +16,11 @@
 # limitations under the License.
 ################################################################################
 rootLogger.level=INFO
-rootLogger.appenderRef.out.ref=FileAppender
+rootLogger.appenderRef.console.ref=ConsoleAppender
 # -----------------------------------------------------------------------------
-# Console (use 'console')
+# Console
 # -----------------------------------------------------------------------------
 appender.console.name=ConsoleAppender
 appender.console.type=CONSOLE
 appender.console.layout.type=PatternLayout
 appender.console.layout.pattern=%d{HH:mm:ss,SSS} [%20t] %-5p %-60c %x - %m%n
-# -----------------------------------------------------------------------------
-# File (use 'file')
-# -----------------------------------------------------------------------------
-appender.file.name=FileAppender
-appender.file.type=FILE
-appender.file.fileName=${sys:log.dir}/mvn-${sys:mvn.forkNumber}.log
-appender.file.layout.type=PatternLayout
-appender.file.layout.pattern=%d{HH:mm:ss,SSS} [%20t] %-5p %-60c %x - %m%n
-
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %10p (%c:%M) - %m%n
-log4j.rootLogger=error,stdout

--- a/flink-paimon-demo/docker-compose.yml
+++ b/flink-paimon-demo/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   # MySQL source database
   mysql-source:
-    image: mysql:8.0
+    image: mysql:8.4.0
     container_name: mysql-source
     environment:
       MYSQL_ROOT_PASSWORD: root

--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,7 @@
         <maven-compiler-plugin.version>3.10.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
         <nacos.version>2.1.2</nacos.version>
-        <httpcore.version>4.4.6</httpcore.version>
-        <httpclient.version>4.5.13</httpclient.version>
         <jackson-annotations.version>2.21</jackson-annotations.version>
-        <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
-        <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
         <confluent.version>7.2.0</confluent.version>
         <docker.host />
         <jackson-databind.version>2.21.4</jackson-databind.version>

--- a/sync_database_mysql/docker-compose.yml
+++ b/sync_database_mysql/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   mysql-source:
-    image: mysql:8.0
+    image: mysql:8.4.0
     container_name: cdc-test-source
     environment:
       MYSQL_ROOT_PASSWORD: root
@@ -26,7 +26,7 @@ services:
       retries: 10
 
   mysql-sink:
-    image: mysql:8.0
+    image: mysql:8.4.0
     container_name: cdc-test-sink
     environment:
       MYSQL_ROOT_PASSWORD: root

--- a/sync_database_mysql/src/main/resources/log4j.properties
+++ b/sync_database_mysql/src/main/resources/log4j.properties
@@ -16,25 +16,11 @@
 # limitations under the License.
 ################################################################################
 rootLogger.level=INFO
-rootLogger.appenderRef.out.ref=FileAppender
+rootLogger.appenderRef.console.ref=ConsoleAppender
 # -----------------------------------------------------------------------------
-# Console (use 'console')
+# Console
 # -----------------------------------------------------------------------------
 appender.console.name=ConsoleAppender
 appender.console.type=CONSOLE
 appender.console.layout.type=PatternLayout
 appender.console.layout.pattern=%d{HH:mm:ss,SSS} [%20t] %-5p %-60c %x - %m%n
-# -----------------------------------------------------------------------------
-# File (use 'file')
-# -----------------------------------------------------------------------------
-appender.file.name=FileAppender
-appender.file.type=FILE
-appender.file.fileName=${sys:log.dir}/mvn-${sys:mvn.forkNumber}.log
-appender.file.layout.type=PatternLayout
-appender.file.layout.pattern=%d{HH:mm:ss,SSS} [%20t] %-5p %-60c %x - %m%n
-
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %10p (%c:%M) - %m%n
-log4j.rootLogger=error,stdout


### PR DESCRIPTION
## Summary

P1+P2 配置清理，共 7 个文件变更：

**P1**:
- **log4j.properties**: 移除混搭的 Log4j 1.x 格式，统一为 Log4j2（Console appender）
- **project-structure.md**: 更新为 5 个模块，修正依赖版本（mysql-connector-j 8.4.0 等）
- **Docker MySQL**: sync_database_mysql + flink-paimon-demo 统一为 `mysql:8.4.0`

**P2**:
- **pre-commit**: 移除无用的 Python lint 工具（isort/black/flake8/autoflake），只保留 spotless
- **pom.xml**: 移除重复 property 定义（maven-shade-plugin、maven-jar-plugin、httpcore/httpclient 死代码）

## Changes

| 文件 | 变更 |
|---|---|
| `flink-demo/src/main/resources/log4j.properties` | 统一 Log4j2 格式 |
| `sync_database_mysql/src/main/resources/log4j.properties` | 统一 Log4j2 格式 |
| `docs/ai-context/project-structure.md` | 更新为 5 模块 + 当前依赖版本 |
| `sync_database_mysql/docker-compose.yml` | mysql:8.0 → 8.4.0 |
| `flink-paimon-demo/docker-compose.yml` | mysql:8.0 → 8.4.0 |
| `.pre-commit-config.yaml` | 移除 Python hooks，只保留 spotless |
| `pom.xml` | 移除重复/死代码 property |

## Test

```bash
./mvnw test -pl sync_database_mysql -Dtest="!*IT,!*IntegrationTest,!*FlinkSqlWDSTest"
# 52 tests passed
```