### PR TITLE
feat: support no-primary-key tables (Issue #166)

### DIFF
--- a/cdc-mysql-sync/src/main/java/io/sophiadata/flink/sync/CDBBatchSink.java
+++ b/cdc-mysql-sync/src/main/java/io/sophiadata/flink/sync/CDBBatchSink.java
@@ -224,19 +224,33 @@ public class CDBBatchSink extends RichSinkFunction<Event> {
         ensureConnection();
         final String colList = "`" + String.join("`,`", columnNames) + "`";
         final String placeholders = String.join(",", Collections.nCopies(columnNames.size(), "?"));
-        final String updateClause =
-                columnNames.stream().map(c -> "`" + c + "`=?").collect(Collectors.joining(","));
-        final String sql =
-                String.format(
-                        "INSERT INTO %s (%s) VALUES (%s) ON DUPLICATE KEY UPDATE %s",
-                        fullTable, colList, placeholders, updateClause);
+
+        final String pk = pks().get(table);
+        final String sql;
+        if (pk != null && !pk.isEmpty()) {
+            final String updateClause =
+                    columnNames.stream().map(c -> "`" + c + "`=?").collect(Collectors.joining(","));
+            sql =
+                    String.format(
+                            "INSERT INTO %s (%s) VALUES (%s) ON DUPLICATE KEY UPDATE %s",
+                            fullTable, colList, placeholders, updateClause);
+        } else {
+            // No primary key — use plain INSERT (append-only semantics)
+            sql =
+                    String.format(
+                            "INSERT INTO %s (%s) VALUES (%s)", fullTable, colList, placeholders);
+        }
 
         try (PreparedStatement ps = conn.prepareStatement(sql)) {
             for (final Record r : upserts) {
                 if (r.after == null) {
                     continue;
                 }
-                bindRow(ps, r.after, columnNames.size());
+                if (pk != null && !pk.isEmpty()) {
+                    bindRow(ps, r.after, columnNames.size());
+                } else {
+                    bindRowPlain(ps, r.after, columnNames.size());
+                }
                 ps.addBatch();
             }
             ps.executeBatch();
@@ -257,7 +271,14 @@ public class CDBBatchSink extends RichSinkFunction<Event> {
             return;
         }
         ensureConnection();
-        final String pk = pks().getOrDefault(table, "id");
+        final String pk = pks().get(table);
+        if (pk == null || pk.isEmpty()) {
+            LOG.warn(
+                    "No primary key for table {}, skipping {} DELETE operations (cannot identify rows to delete)",
+                    table,
+                    deletes.size());
+            return;
+        }
         final String deleteSql = String.format("DELETE FROM %s WHERE `%s` = ?", fullTable, pk);
 
         try (PreparedStatement ps = conn.prepareStatement(deleteSql)) {
@@ -290,6 +311,15 @@ public class CDBBatchSink extends RichSinkFunction<Event> {
             final Object val = i < row.length ? row[i] : null;
             ps.setObject(i + 1, val);
             ps.setObject(i + 1 + columnCount, val);
+        }
+    }
+
+    /** Bind row values for plain INSERT (no ON DUPLICATE KEY UPDATE). */
+    private void bindRowPlain(final PreparedStatement ps, final Object[] row, final int columnCount)
+            throws SQLException {
+        for (int i = 0; i < columnCount; i++) {
+            final Object val = i < row.length ? row[i] : null;
+            ps.setObject(i + 1, val);
         }
     }
 

--- a/cdc-mysql-sync/src/main/java/io/sophiadata/flink/sync/FlinkSqlWDS.java
+++ b/cdc-mysql-sync/src/main/java/io/sophiadata/flink/sync/FlinkSqlWDS.java
@@ -249,7 +249,7 @@ public class FlinkSqlWDS extends BaseCode {
         schemas.put(tableName, colMap);
         final String pk =
                 cte.getSchema().primaryKeys().isEmpty()
-                        ? "id"
+                        ? null
                         : cte.getSchema().primaryKeys().get(0);
         pks.put(tableName, pk);
         MysqlUtil.createSinkTableIfNotExists(
@@ -322,7 +322,7 @@ public class FlinkSqlWDS extends BaseCode {
 
             for (final String table : tables) {
                 final Map<String, String> cols = new LinkedHashMap<>();
-                String pk = "id";
+                String pk = null;
                 try (PreparedStatement psCol =
                         conn.prepareStatement(
                                 "SELECT COLUMN_NAME, DATA_TYPE, ORDINAL_POSITION FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? ORDER BY ORDINAL_POSITION")) {

--- a/cdc-mysql-sync/src/main/java/io/sophiadata/flink/sync/util/MysqlUtil.java
+++ b/cdc-mysql-sync/src/main/java/io/sophiadata/flink/sync/util/MysqlUtil.java
@@ -111,7 +111,13 @@ public final class MysqlUtil {
             }
             stmt.append(",\n");
         }
-        stmt.append("  PRIMARY KEY (").append(String.join(",", primaryKeys)).append(")\n)");
+        if (primaryKeys != null && !primaryKeys.isEmpty()) {
+            stmt.append("  PRIMARY KEY (").append(String.join(",", primaryKeys)).append(")\n)");
+        } else {
+            // Remove trailing comma from last column
+            stmt.setLength(stmt.length() - 2);
+            stmt.append("\n)");
+        }
 
         final String createSql = stmt.toString();
         LOG.debug("Generated SQL: {}", createSql);
@@ -138,13 +144,11 @@ public final class MysqlUtil {
                 throw new IllegalArgumentException("Invalid column name: " + field);
             }
         }
-        if (primaryKeys == null || primaryKeys.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "primaryKeys must be non-empty (CDC requires a primary key)");
-        }
-        for (final String pk : primaryKeys) {
-            if (!isValidIdentifier(pk)) {
-                throw new IllegalArgumentException("Invalid primary key: " + pk);
+        if (primaryKeys != null) {
+            for (final String pk : primaryKeys) {
+                if (!isValidIdentifier(pk)) {
+                    throw new IllegalArgumentException("Invalid primary key: " + pk);
+                }
             }
         }
     }
@@ -217,9 +221,15 @@ public final class MysqlUtil {
             cl.append("`").append(e.getKey()).append("` ").append(mapType(e.getValue()));
             i++;
         }
-        final String sql =
-                String.format(
-                        "CREATE TABLE IF NOT EXISTS `%s` (%s, PRIMARY KEY(`%s`))", table, cl, pk);
+        final String sql;
+        if (pk != null && !pk.isEmpty()) {
+            sql =
+                    String.format(
+                            "CREATE TABLE IF NOT EXISTS `%s` (%s, PRIMARY KEY(`%s`))",
+                            table, cl, pk);
+        } else {
+            sql = String.format("CREATE TABLE IF NOT EXISTS `%s` (%s)", table, cl);
+        }
         try (Connection c = DriverManager.getConnection(jdbcUrl, user, pass);
                 Statement s = c.createStatement()) {
             s.executeUpdate(sql);

--- a/cdc-mysql-sync/src/test/java/io/sophiadata/flink/sync/util/MysqlUtilTest.java
+++ b/cdc-mysql-sync/src/test/java/io/sophiadata/flink/sync/util/MysqlUtilTest.java
@@ -118,13 +118,14 @@ class MysqlUtilTest {
     }
 
     @Test
-    void createTable_rejectsEmptyPrimaryKey() {
-        DataType[] types = {DataTypes.BIGINT()};
-        assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                        MysqlUtil.createTable(
-                                "t", new String[] {"id"}, types, Collections.emptyList()));
+    void createTable_noPrimaryKey_generatesValidSql() {
+        DataType[] types = {DataTypes.BIGINT(), DataTypes.VARCHAR(10)};
+        String sql =
+                MysqlUtil.createTable(
+                        "t", new String[] {"id", "name"}, types, Collections.emptyList());
+        assertTrue(sql.contains("`id` BIGINT"), sql);
+        assertTrue(sql.contains("`name` VARCHAR(10)"), sql);
+        assertFalse(sql.contains("PRIMARY KEY"), sql);
     }
 
     @Test


### PR DESCRIPTION
## Summary

支持无主键表的 CDC 整库同步（Issue #166）。

Flink CDC 2.4.0+ 已支持无主键表（需配置 `scan.incremental.snapshot.chunk.key-column`），但本项目 Sink 侧在 6 个位置强制假设主键存在。本次改动适配无 PK 场景：

**MysqlUtil**:
- `createTable()`: 空主键列表时跳过 `PRIMARY KEY` 子句
- `createSinkTableIfNotExists()`: pk 为空时跳过 `PRIMARY KEY` 拼接

**FlinkSqlWDS**:
- `bootstrapSinkTables()`: 无主键时 pk 设为 null（不再 fallback "id"）
- `handleCreateTable()`: CDC 上报无主键时 pk 设为 null

**CDBBatchSink**:
- `flushUpserts()`: 无 PK 时用 `INSERT INTO ... VALUES` 替代 `INSERT ... ON DUPLICATE KEY UPDATE`
- `flushDeletes()`: 无 PK 时跳过 DELETE 并记录 WARN（无法定位行）

**MysqlUtilTest**:
- 更新 `createTable_rejectsEmptyPrimaryKey` → `createTable_noPrimaryKey_generatesValidSql`

## Usage

无主键表需在 CDC Source 配置中指定分片键：

```java
MySqlSource.builder()
    .databaseList("db")
    .tableList("db.no_pk_table")
    .startupOptions(StartupOptions.initial())
    // 必须指定分片键
    .scanIncrementalSnapshotChunkKeyColumn("db.no_pk_table", "some_column")
    ...
```

## Test

```bash
./mvnw test -pl cdc-mysql-sync -Dtest="!*IT,!*IntegrationTest,!*FlinkSqlWDSTest"
# 52 tests passed
```