### PR TITLE
chore: code cleanup — tests, JUnit 5, visibility

### DIFF
--- a/cdc-mysql-sync/src/main/java/io/sophiadata/flink/sync/CDBBatchSink.java
+++ b/cdc-mysql-sync/src/main/java/io/sophiadata/flink/sync/CDBBatchSink.java
@@ -193,7 +193,7 @@ public class CDBBatchSink extends RichSinkFunction<Event> {
         conn.commit();
     }
 
-    private final Map<String, List<Record>> groupByTable(final List<Record> records) {
+    final Map<String, List<Record>> groupByTable(final List<Record> records) {
         final Map<String, List<Record>> byTable = new LinkedHashMap<>();
         for (final Record r : records) {
             byTable.computeIfAbsent(r.tableName, k -> new ArrayList<>()).add(r);
@@ -201,7 +201,7 @@ public class CDBBatchSink extends RichSinkFunction<Event> {
         return byTable;
     }
 
-    private void splitByOperation(
+    void splitByOperation(
             final List<Record> records, final List<Record> upserts, final List<Record> deletes) {
         for (final Record r : records) {
             if (r.op == OperationType.DELETE) {
@@ -372,8 +372,7 @@ public class CDBBatchSink extends RichSinkFunction<Event> {
             this.after = extractValues(event.after());
         }
 
-        private static Object[] extractValues(
-                final org.apache.flink.cdc.common.data.RecordData row) {
+        static Object[] extractValues(final org.apache.flink.cdc.common.data.RecordData row) {
             if (row == null) {
                 return null;
             }

--- a/cdc-mysql-sync/src/test/java/io/sophiadata/flink/cdc/MySqlSourceExampleTest.java
+++ b/cdc-mysql-sync/src/test/java/io/sophiadata/flink/cdc/MySqlSourceExampleTest.java
@@ -23,9 +23,10 @@ import org.apache.flink.table.api.StatementSet;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 
 import io.sophiadata.flink.utils.UniqueDatabase;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Integration test for Flink CDC 3.6 whole database sync using SQL connector.
@@ -46,9 +47,9 @@ public class MySqlSourceExampleTest extends MySqlSourceTestBase {
 
     @Test
     public void testWholeDatabaseSync() throws Exception {
-        org.junit.Assume.assumeTrue(
-                "set -DrunIntegrationTests=true to run the CDC integration test",
-                Boolean.getBoolean("runIntegrationTests"));
+        Assumptions.assumeTrue(
+                Boolean.getBoolean("runIntegrationTests"),
+                "set -DrunIntegrationTests=true to run the CDC integration test");
 
         inventoryDatabase.createAndInitialize();
 
@@ -129,6 +130,6 @@ public class MySqlSourceExampleTest extends MySqlSourceTestBase {
         runner.interrupt();
 
         // Verify sink table exists (basic smoke test)
-        assertTrue("CDC sync completed without exception", true);
+        assertTrue(true, "CDC sync completed without exception");
     }
 }

--- a/cdc-mysql-sync/src/test/java/io/sophiadata/flink/sync/CDBBatchSinkTest.java
+++ b/cdc-mysql-sync/src/test/java/io/sophiadata/flink/sync/CDBBatchSinkTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sophiadata.flink.sync;
+
+import org.apache.flink.cdc.common.data.GenericRecordData;
+import org.apache.flink.cdc.common.event.DataChangeEvent;
+import org.apache.flink.cdc.common.event.OperationType;
+import org.apache.flink.cdc.common.event.TableId;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CDBBatchSinkTest {
+
+    private CDBBatchSink sink;
+
+    @BeforeEach
+    void setUp() {
+        sink = new CDBBatchSink("jdbc:mysql://localhost:3306/test", "root", "pass", 100, 1000);
+    }
+
+    // --- Record.extractValues tests ---
+
+    @Test
+    void record_extractValues_nullRow_returnsNull() {
+        Object[] values = CDBBatchSink.Record.extractValues(null);
+        assertNull(values);
+    }
+
+    @Test
+    void record_extractValues_extractsAllFields() {
+        Object[] row = new Object[] {1L, "Alice", 30};
+        GenericRecordData recordData = GenericRecordData.of(row);
+
+        Object[] values = CDBBatchSink.Record.extractValues(recordData);
+        assertNotNull(values);
+        assertEquals(3, values.length);
+        assertEquals(1L, values[0]);
+        assertEquals("Alice", values[1]);
+        assertEquals(30, values[2]);
+    }
+
+    // --- groupByTable tests ---
+
+    @Test
+    void groupByTable_groupsRecordsByTableName() {
+        TableId tid1 = TableId.tableId("db", "table1");
+        TableId tid2 = TableId.tableId("db", "table2");
+
+        CDBBatchSink.Record r1 =
+                new CDBBatchSink.Record(
+                        DataChangeEvent.insertEvent(tid1, GenericRecordData.of(new Object[] {1L})));
+        CDBBatchSink.Record r2 =
+                new CDBBatchSink.Record(
+                        DataChangeEvent.insertEvent(tid2, GenericRecordData.of(new Object[] {2L})));
+        CDBBatchSink.Record r3 =
+                new CDBBatchSink.Record(
+                        DataChangeEvent.insertEvent(tid1, GenericRecordData.of(new Object[] {3L})));
+
+        List<CDBBatchSink.Record> records = Arrays.asList(r1, r2, r3);
+        Map<String, List<CDBBatchSink.Record>> grouped = sink.groupByTable(records);
+
+        assertEquals(2, grouped.size());
+        assertEquals(2, grouped.get("table1").size());
+        assertEquals(1, grouped.get("table2").size());
+    }
+
+    @Test
+    void groupByTable_emptyList_returnsEmptyMap() {
+        Map<String, List<CDBBatchSink.Record>> grouped = sink.groupByTable(new ArrayList<>());
+        assertTrue(grouped.isEmpty());
+    }
+
+    // --- splitByOperation tests ---
+
+    @Test
+    void splitByOperation_separatesUpsertsAndDeletes() {
+        TableId tid = TableId.tableId("db", "table");
+
+        CDBBatchSink.Record insert =
+                new CDBBatchSink.Record(
+                        DataChangeEvent.insertEvent(tid, GenericRecordData.of(new Object[] {1L})));
+        CDBBatchSink.Record update =
+                new CDBBatchSink.Record(
+                        DataChangeEvent.updateEvent(
+                                tid,
+                                GenericRecordData.of(new Object[] {1L}),
+                                GenericRecordData.of(new Object[] {2L})));
+        CDBBatchSink.Record delete =
+                new CDBBatchSink.Record(
+                        DataChangeEvent.deleteEvent(tid, GenericRecordData.of(new Object[] {3L})));
+
+        List<CDBBatchSink.Record> upserts = new ArrayList<>();
+        List<CDBBatchSink.Record> deletes = new ArrayList<>();
+        sink.splitByOperation(Arrays.asList(insert, update, delete), upserts, deletes);
+
+        assertEquals(2, upserts.size());
+        assertEquals(1, deletes.size());
+        assertEquals(OperationType.DELETE, deletes.get(0).op);
+    }
+
+    @Test
+    void splitByOperation_allUpserts_noDeletes() {
+        TableId tid = TableId.tableId("db", "table");
+        CDBBatchSink.Record insert =
+                new CDBBatchSink.Record(
+                        DataChangeEvent.insertEvent(tid, GenericRecordData.of(new Object[] {1L})));
+
+        List<CDBBatchSink.Record> upserts = new ArrayList<>();
+        List<CDBBatchSink.Record> deletes = new ArrayList<>();
+        sink.splitByOperation(Arrays.asList(insert), upserts, deletes);
+
+        assertEquals(1, upserts.size());
+        assertEquals(0, deletes.size());
+    }
+}

--- a/e2e-tests/src/test/java/io/sophiadata/flink/sync/sink/CreateMysqlLSinkTableIT.java
+++ b/e2e-tests/src/test/java/io/sophiadata/flink/sync/sink/CreateMysqlLSinkTableIT.java
@@ -22,7 +22,8 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.types.DataType;
 
 import io.sophiadata.flink.sync.util.MysqlUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import java.sql.Connection;
@@ -32,11 +33,10 @@ import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Integration test for {@link MysqlUtil#createTable} — runs the generated DDL against a real MySQL
@@ -57,9 +57,9 @@ public class CreateMysqlLSinkTableIT {
 
     @Test
     public void testCreateTableAgainstRealMySQL() throws SQLException, ClassNotFoundException {
-        assumeTrue(
-                "set -DrunIntegrationTests=true to enable the sink-DDL integration test",
-                Boolean.getBoolean("runIntegrationTests"));
+        Assumptions.assumeTrue(
+                Boolean.getBoolean("runIntegrationTests"),
+                "set -DrunIntegrationTests=true to enable the sink-DDL integration test");
 
         String externalUrl = System.getProperty("mysql.test.url");
         String user = System.getProperty("mysql.test.user", "root");
@@ -73,7 +73,7 @@ public class CreateMysqlLSinkTableIT {
             try {
                 container.start();
             } catch (Throwable t) {
-                assumeTrue("Docker unavailable: " + t.getMessage(), false);
+                Assumptions.assumeTrue(false, "Docker unavailable: " + t.getMessage());
                 return;
             }
             try {
@@ -127,11 +127,11 @@ public class CreateMysqlLSinkTableIT {
                     String def = rs.getString("COLUMN_DEFAULT");
                     assertNotNull(def);
                     assertTrue(
-                            "default should be 1970-01-01 09:00:00, got: " + def,
-                            def.startsWith("1970-01-01 09:00:00"));
+                            def.startsWith("1970-01-01 09:00:00"),
+                            "default should be 1970-01-01 09:00:00, got: " + def);
                 }
             }
-            assertEquals("expected exactly 4 columns", 4, count);
+            assertEquals(4, count, "expected exactly 4 columns");
         }
 
         try (Connection c = MysqlUtil.getConnection(url, user, pw);

--- a/flink-demo/src/test/java/io/sophiadata/flink/source/MockSourceFunctionTest.java
+++ b/flink-demo/src/test/java/io/sophiadata/flink/source/MockSourceFunctionTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sophiadata.flink.source;
+
+import io.sophiadata.flink.source.bean.AppMain;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class MockSourceFunctionTest {
+
+    @Test
+    void doAppMock_returnsNonEmptyList() {
+        MockSourceFunction source = new MockSourceFunction();
+        List<AppMain> result = source.doAppMock();
+        assertNotNull(result);
+        assertFalse(result.isEmpty(), "doAppMock should return at least one event");
+    }
+
+    @Test
+    void doAppMock_firstEventIsStart() {
+        MockSourceFunction source = new MockSourceFunction();
+        List<AppMain> result = source.doAppMock();
+        assertNotNull(result.get(0).getStart(), "First event should be an AppStart");
+    }
+
+    @Test
+    void doAppMock_containsPageEvents() {
+        MockSourceFunction source = new MockSourceFunction();
+        List<AppMain> result = source.doAppMock();
+        boolean hasPages = result.stream().anyMatch(e -> e.getPage() != null);
+        assertTrue(hasPages, "Should contain at least one page event");
+    }
+
+    private static void assertTrue(boolean condition, String message) {
+        org.junit.jupiter.api.Assertions.assertTrue(condition, message);
+    }
+}


### PR DESCRIPTION
## Summary

三项代码清理，一个 PR 搞定：

**1. CDBBatchSink 单元测试**：
- 新增 `CDBBatchSinkTest.java`（6 个测试）
- 测试 `groupByTable`、`splitByOperation`、`Record.extractValues`
- 暴露方法为包级可见以便测试

**2. JUnit 4→5 迁移**：
- `MySqlSourceExampleTest`：`org.junit.Test` → `org.junit.jupiter.api.Test`
- `CreateMysqlLSinkTableIT`：同上 + `assumeTrue` → `Assumptions.assumeTrue`
- `SchemaEvolutionIT` 保留 JUnit 4（`@Rule MiniClusterWithClientResource` 无 JUnit 5 适配）

**3. MockSourceFunction 单元测试**：
- 新增 `MockSourceFunctionTest.java`（3 个测试）
- 测试 `doAppMock()` 返回非空列表、首事件是 AppStart、包含页面事件

## Test

```bash
./mvnw test -pl cdc-mysql-sync,flink-demo -Dtest="!*IT,!*IntegrationTest,!*FlinkSqlWDSTest"
# All tests passed (flink-demo: 66, cdc-mysql-sync: 59)
```