### PR TITLE
refactor(test): extract AbstractMysqlSyncIT base class and add unit tests

### DIFF
--- a/cdc-mysql-sync/src/test/java/io/sophiadata/flink/sync/CDBBatchSinkTest.java
+++ b/cdc-mysql-sync/src/test/java/io/sophiadata/flink/sync/CDBBatchSinkTest.java
@@ -139,4 +139,63 @@ class CDBBatchSinkTest {
         assertEquals(1, upserts.size());
         assertEquals(0, deletes.size());
     }
+
+    // --- Record construction tests ---
+
+    @Test
+    void record_insertEvent_hasCorrectFields() {
+        TableId tid = TableId.tableId("db", "users");
+        DataChangeEvent dce =
+                DataChangeEvent.insertEvent(tid, GenericRecordData.of(new Object[] {1L, "Alice"}));
+        CDBBatchSink.Record rec = new CDBBatchSink.Record(dce);
+
+        assertEquals("users", rec.tableName);
+        assertEquals(OperationType.INSERT, rec.op);
+        assertNull(rec.before);
+        assertNotNull(rec.after);
+        assertEquals(2, rec.after.length);
+        assertEquals(1L, rec.after[0]);
+        assertEquals("Alice", rec.after[1]);
+    }
+
+    @Test
+    void record_updateEvent_hasBothBeforeAndAfter() {
+        TableId tid = TableId.tableId("db", "users");
+        DataChangeEvent dce =
+                DataChangeEvent.updateEvent(
+                        tid,
+                        GenericRecordData.of(new Object[] {1L, "Alice"}),
+                        GenericRecordData.of(new Object[] {1L, "Bob"}));
+        CDBBatchSink.Record rec = new CDBBatchSink.Record(dce);
+
+        assertEquals(OperationType.UPDATE, rec.op);
+        assertNotNull(rec.before);
+        assertNotNull(rec.after);
+        assertEquals("Alice", rec.before[1]);
+        assertEquals("Bob", rec.after[1]);
+    }
+
+    @Test
+    void record_deleteEvent_hasBeforeOnly() {
+        TableId tid = TableId.tableId("db", "users");
+        DataChangeEvent dce =
+                DataChangeEvent.deleteEvent(tid, GenericRecordData.of(new Object[] {1L, "Alice"}));
+        CDBBatchSink.Record rec = new CDBBatchSink.Record(dce);
+
+        assertEquals(OperationType.DELETE, rec.op);
+        assertNotNull(rec.before);
+        assertNull(rec.after);
+    }
+
+    // --- invoke behavior test ---
+
+    @Test
+    void invoke_nonDataChangeEvent_ignored() throws Exception {
+        org.apache.flink.cdc.common.event.Event nonDataEvent =
+                new org.apache.flink.cdc.common.event.TruncateTableEvent(
+                        TableId.tableId("db", "table"));
+        sink.invoke(nonDataEvent, null);
+        // Should not throw, batch should remain empty
+        assertTrue(sink.groupByTable(new ArrayList<>()).isEmpty());
+    }
 }

--- a/cdc-mysql-sync/src/test/java/io/sophiadata/flink/sync/schema/SchemaEvolverTest.java
+++ b/cdc-mysql-sync/src/test/java/io/sophiadata/flink/sync/schema/SchemaEvolverTest.java
@@ -189,6 +189,49 @@ class SchemaEvolverTest {
         evolver.shutdown();
     }
 
+    // --- thread safety ---
+
+    @Test
+    void processEvent_concurrentEvents_doNotThrow() throws InterruptedException {
+        SchemaEvolver evolver = createEvolver();
+        Thread t1 =
+                new Thread(
+                        () -> {
+                            for (int i = 0; i < 10; i++) {
+                                evolver.processEvent(
+                                        new CreateTableEvent(
+                                                TableId.tableId("testdb", "t1"),
+                                                Schema.newBuilder()
+                                                        .column(
+                                                                Column.physicalColumn(
+                                                                        "id", DataTypes.BIGINT()))
+                                                        .primaryKey(Collections.singletonList("id"))
+                                                        .build()));
+                            }
+                        });
+        Thread t2 =
+                new Thread(
+                        () -> {
+                            for (int i = 0; i < 10; i++) {
+                                evolver.processEvent(
+                                        new CreateTableEvent(
+                                                TableId.tableId("testdb", "t2"),
+                                                Schema.newBuilder()
+                                                        .column(
+                                                                Column.physicalColumn(
+                                                                        "id", DataTypes.BIGINT()))
+                                                        .primaryKey(Collections.singletonList("id"))
+                                                        .build()));
+                            }
+                        });
+        t1.start();
+        t2.start();
+        t1.join(5000);
+        t2.join(5000);
+        // No exception means thread safety is working
+        evolver.shutdown();
+    }
+
     // --- helpers ---
 
     private SchemaEvolver createEvolver() {

--- a/e2e-tests/src/test/java/io/sophiadata/flink/sync/AbstractMysqlSyncIT.java
+++ b/e2e-tests/src/test/java/io/sophiadata/flink/sync/AbstractMysqlSyncIT.java
@@ -1,0 +1,316 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sophiadata.flink.sync;
+
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+
+import io.sophiadata.flink.utils.MySqlContainer;
+import io.sophiadata.flink.utils.MySqlVersion;
+import org.junit.Rule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Base class for MySQL CDC end-to-end integration tests.
+ *
+ * <p>Provides common infrastructure: Testcontainers MySQL (source + sink), Flink MiniCluster, CDC
+ * user setup, pipeline lifecycle, and helper methods for assertions.
+ */
+public abstract class AbstractMysqlSyncIT {
+
+    protected static final Logger LOG = LoggerFactory.getLogger(AbstractMysqlSyncIT.class);
+
+    protected static final String SOURCE_DB = "flink_source";
+    protected static final String SINK_DB = "flink_sink";
+
+    @Rule
+    public MiniClusterWithClientResource miniClusterResource =
+            new MiniClusterWithClientResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(1)
+                            .setConfiguration(createMiniClusterConfig())
+                            .build());
+
+    private static Configuration createMiniClusterConfig() {
+        Configuration config = new Configuration();
+        config.set(TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.ofMebiBytes(512));
+        config.set(TaskManagerOptions.TASK_OFF_HEAP_MEMORY, MemorySize.ofMebiBytes(128));
+        config.set(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY, MemorySize.ofMebiBytes(256));
+        config.set(TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY, MemorySize.ofMebiBytes(64));
+        return config;
+    }
+
+    protected JdbcDatabaseContainer<?> sourceContainer;
+    protected JdbcDatabaseContainer<?> sinkContainer;
+
+    protected String sourceUrl;
+    protected String sinkUrl;
+    protected String sourceHost;
+    protected int sourcePort;
+
+    protected StreamExecutionEnvironment env;
+    protected StreamTableEnvironment tEnv;
+    protected Thread flinkJobThread;
+
+    /**
+     * Start MySQL containers and create CDC user. Subclasses call this from {@code @Before} and
+     * then create their specific source tables.
+     */
+    protected void startMysqlContainers() throws Exception {
+        sourceContainer =
+                new MySqlContainer(MySqlVersion.V8_0)
+                        .withDatabaseName(SOURCE_DB)
+                        .withUsername("root")
+                        .withPassword("root")
+                        .withConfigurationOverride("docker.cnf");
+        sourceContainer.start();
+
+        sinkContainer =
+                new MySqlContainer(MySqlVersion.V8_0)
+                        .withDatabaseName(SINK_DB)
+                        .withUsername("root")
+                        .withPassword("root");
+        sinkContainer.start();
+
+        sourceHost = sourceContainer.getHost();
+        sourcePort = sourceContainer.getMappedPort(3306);
+        sourceUrl =
+                "jdbc:mysql://"
+                        + sourceHost
+                        + ":"
+                        + sourcePort
+                        + "/"
+                        + SOURCE_DB
+                        + "?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC";
+        sinkUrl =
+                "jdbc:mysql://"
+                        + sinkContainer.getHost()
+                        + ":"
+                        + sinkContainer.getMappedPort(3306)
+                        + "/"
+                        + SINK_DB
+                        + "?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC";
+
+        LOG.info("Source MySQL: {}", sourceUrl);
+        LOG.info("Sink MySQL: {}", sinkUrl);
+
+        // Create CDC user with replication privileges on source
+        try (Connection c =
+                        DriverManager.getConnection(
+                                "jdbc:mysql://"
+                                        + sourceHost
+                                        + ":"
+                                        + sourcePort
+                                        + "/?useSSL=false&allowPublicKeyRetrieval=true",
+                                "root",
+                                "root");
+                Statement st = c.createStatement()) {
+            st.executeUpdate(
+                    "CREATE USER IF NOT EXISTS 'cdc_user'@'%' IDENTIFIED BY 'cdc_password'");
+            st.executeUpdate(
+                    "GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, "
+                            + "REPLICATION CLIENT, LOCK TABLES ON *.* TO 'cdc_user'@'%'");
+            st.executeUpdate("FLUSH PRIVILEGES");
+        }
+    }
+
+    /**
+     * Stop containers and clean up Flink pipeline thread. Subclasses call this from {@code @After}.
+     */
+    protected void stopMysqlContainers() {
+        if (flinkJobThread != null) {
+            try {
+                flinkJobThread.join(15000);
+            } catch (InterruptedException ignored) {
+            }
+            if (flinkJobThread.isAlive()) {
+                flinkJobThread.interrupt();
+                try {
+                    flinkJobThread.join(5000);
+                } catch (InterruptedException ignored) {
+                }
+            }
+        }
+        if (sourceContainer != null) sourceContainer.stop();
+        if (sinkContainer != null) sinkContainer.stop();
+    }
+
+    // ---- Flink pipeline helpers ----
+
+    protected void startFlinkPipeline(String pipelineName) {
+        env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
+        env.setParallelism(1);
+        env.enableCheckpointing(2000);
+        tEnv = StreamTableEnvironment.create(env);
+        tEnv.getConfig()
+                .getConfiguration()
+                .setString("pipeline.name", pipelineName + "-" + System.currentTimeMillis());
+
+        Map<String, String> args = new HashMap<>();
+        args.put("hostname", sourceHost);
+        args.put("port", String.valueOf(sourcePort));
+        args.put("username", "root");
+        args.put("password", "root");
+        args.put("databaseName", SOURCE_DB);
+        args.put("tableList", SOURCE_DB + ".*");
+        args.put("sinkUrl", sinkUrl);
+        args.put("sinkUsername", "root");
+        args.put("sinkPassword", "root");
+        args.put("serverTimeZone", "UTC");
+        args.put("setParallelism", "1");
+        args.put("cdcSourceName", "mysql-cdc-e2e");
+
+        flinkJobThread =
+                new Thread(
+                        () -> {
+                            try {
+                                new FlinkSqlWDS().handle(toArgs(args), env, tEnv);
+                            } catch (Exception e) {
+                                LOG.error("Flink pipeline failed", e);
+                            }
+                        },
+                        "flink-wds-e2e");
+        flinkJobThread.setDaemon(true);
+        flinkJobThread.start();
+    }
+
+    // ---- JDBC helpers ----
+
+    protected Connection getSourceConnection() throws SQLException {
+        return DriverManager.getConnection(sourceUrl, "root", "root");
+    }
+
+    protected Connection getSinkConnection() throws SQLException {
+        return DriverManager.getConnection(sinkUrl, "root", "root");
+    }
+
+    /** Wait until the CDC pipeline's bootstrap has created the specified sink table. */
+    @SuppressWarnings("BusyWait")
+    protected void waitForSinkTable(String table, int timeoutSeconds) throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds);
+        while (System.nanoTime() < deadline) {
+            try (Connection c = getSinkConnection();
+                    ResultSet rs =
+                            c.createStatement()
+                                    .executeQuery(
+                                            "SELECT COUNT(*) FROM " + SINK_DB + "." + table)) {
+                if (rs.next()) {
+                    LOG.info("Sink table {} is ready", table);
+                    TimeUnit.SECONDS.sleep(5);
+                    return;
+                }
+            } catch (Exception ignored) {
+            }
+            Thread.sleep(1000);
+        }
+        assertTrue("Timed out waiting for sink table " + table, false);
+    }
+
+    @SuppressWarnings("BusyWait")
+    protected void waitForSinkRowCount(String table, int expected, int timeoutSeconds)
+            throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds);
+        int count = 0;
+        while (System.nanoTime() < deadline) {
+            try (Connection c = getSinkConnection();
+                    Statement st = c.createStatement();
+                    ResultSet rs =
+                            st.executeQuery("SELECT COUNT(*) FROM " + SINK_DB + "." + table)) {
+                if (rs.next()) {
+                    count = rs.getInt(1);
+                    if (count >= expected) return;
+                }
+            } catch (Exception ignored) {
+            }
+            Thread.sleep(2000);
+        }
+        assertTrue(
+                "Expected at least " + expected + " rows in " + table + ", got " + count,
+                count >= expected);
+    }
+
+    protected void assertSinkRow(String table, String column, String value) throws SQLException {
+        try (Connection c = getSinkConnection();
+                Statement st = c.createStatement();
+                ResultSet rs =
+                        st.executeQuery(
+                                "SELECT COUNT(*) FROM "
+                                        + SINK_DB
+                                        + "."
+                                        + table
+                                        + " WHERE "
+                                        + column
+                                        + " = '"
+                                        + value
+                                        + "'")) {
+            assertTrue("row with " + column + "=" + value + " should exist", rs.next());
+            assertTrue("expected at least 1 row with " + column + "=" + value, rs.getInt(1) >= 1);
+        }
+    }
+
+    protected void assertSinkValue(
+            String table, String whereCol, String whereVal, String selectCol, Object expected)
+            throws SQLException {
+        try (Connection c = getSinkConnection();
+                Statement st = c.createStatement();
+                ResultSet rs =
+                        st.executeQuery(
+                                "SELECT " + selectCol + " FROM " + SINK_DB + "." + table + " WHERE "
+                                        + whereCol + " = '" + whereVal + "'")) {
+            assertTrue("row with " + whereCol + "=" + whereVal + " should exist", rs.next());
+            if (expected instanceof Integer) {
+                assertEquals("value mismatch", ((Integer) expected).intValue(), rs.getInt(1));
+            } else {
+                assertEquals("value mismatch", expected, rs.getObject(1));
+            }
+        }
+    }
+
+    protected static String[] toArgs(Map<String, String> m) {
+        String[] out = new String[m.size() * 2];
+        int i = 0;
+        for (Map.Entry<String, String> e : m.entrySet()) {
+            out[i++] = "--" + e.getKey();
+            out[i++] = e.getValue();
+        }
+        return out;
+    }
+}

--- a/e2e-tests/src/test/java/io/sophiadata/flink/sync/SchemaEvolutionIT.java
+++ b/e2e-tests/src/test/java/io/sophiadata/flink/sync/SchemaEvolutionIT.java
@@ -18,32 +18,13 @@
 
 package io.sophiadata.flink.sync;
 
-import org.apache.flink.api.common.RuntimeExecutionMode;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
-import org.apache.flink.test.util.MiniClusterWithClientResource;
-
-import io.sophiadata.flink.utils.MySqlContainer;
-import io.sophiadata.flink.utils.MySqlVersion;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
@@ -54,100 +35,12 @@ import static org.junit.Assert.assertTrue;
  * pipeline, simulates DDL changes (ADD COLUMN, MODIFY COLUMN, DROP+RE-ADD), verifies data + schema
  * evolution synced to sink.
  */
-public class SchemaEvolutionIT {
-
-    private static final Logger LOG = LoggerFactory.getLogger(SchemaEvolutionIT.class);
-
-    private static final String SOURCE_DB = "flink_source";
-    private static final String SINK_DB = "flink_sink";
-
-    @Rule
-    public MiniClusterWithClientResource miniClusterResource =
-            new MiniClusterWithClientResource(
-                    new MiniClusterResourceConfiguration.Builder()
-                            .setNumberTaskManagers(1)
-                            .setNumberSlotsPerTaskManager(1)
-                            .setConfiguration(createMiniClusterConfig())
-                            .build());
-
-    private static Configuration createMiniClusterConfig() {
-        Configuration config = new Configuration();
-        // Limit TaskManager memory to fit within CI runner (16 GB)
-        config.set(TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.ofMebiBytes(512));
-        config.set(TaskManagerOptions.TASK_OFF_HEAP_MEMORY, MemorySize.ofMebiBytes(128));
-        config.set(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY, MemorySize.ofMebiBytes(256));
-        config.set(TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY, MemorySize.ofMebiBytes(64));
-        return config;
-    }
-
-    private JdbcDatabaseContainer<?> sourceContainer;
-    private JdbcDatabaseContainer<?> sinkContainer;
-
-    private String sourceUrl;
-    private String sinkUrl;
-
-    private StreamExecutionEnvironment env;
-    private StreamTableEnvironment tEnv;
-    private Thread flinkJobThread;
+public class SchemaEvolutionIT extends AbstractMysqlSyncIT {
 
     @Before
     public void setUp() throws Exception {
-        // Source: enable ROW binlog for CDC
-        sourceContainer =
-                new MySqlContainer(MySqlVersion.V8_0)
-                        .withDatabaseName(SOURCE_DB)
-                        .withUsername("root")
-                        .withPassword("root")
-                        .withConfigurationOverride("docker.cnf");
-        sourceContainer.start();
+        startMysqlContainers();
 
-        // Sink: plain MySQL
-        sinkContainer =
-                new MySqlContainer(MySqlVersion.V8_0)
-                        .withDatabaseName(SINK_DB)
-                        .withUsername("root")
-                        .withPassword("root");
-        sinkContainer.start();
-
-        sourceUrl =
-                "jdbc:mysql://"
-                        + sourceContainer.getHost()
-                        + ":"
-                        + sourceContainer.getMappedPort(3306)
-                        + "/"
-                        + SOURCE_DB
-                        + "?useSSL=false&allowPublicKeyRetrieval=true";
-        sinkUrl =
-                "jdbc:mysql://"
-                        + sinkContainer.getHost()
-                        + ":"
-                        + sinkContainer.getMappedPort(3306)
-                        + "/"
-                        + SINK_DB
-                        + "?useSSL=false&allowPublicKeyRetrieval=true";
-
-        LOG.info("Source MySQL: {}", sourceUrl);
-        LOG.info("Sink MySQL: {}", sinkUrl);
-
-        // Create CDC user with replication privileges on source
-        try (Connection c =
-                        DriverManager.getConnection(
-                                "jdbc:mysql://"
-                                        + sourceContainer.getHost()
-                                        + ":"
-                                        + sourceContainer.getMappedPort(3306)
-                                        + "/?useSSL=false&allowPublicKeyRetrieval=true",
-                                "root",
-                                "root");
-                Statement st = c.createStatement()) {
-            st.executeUpdate(
-                    "CREATE USER IF NOT EXISTS 'cdc_user'@'%' IDENTIFIED BY 'cdc_password'");
-            st.executeUpdate(
-                    "GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'cdc_user'@'%'");
-            st.executeUpdate("FLUSH PRIVILEGES");
-        }
-
-        // Create source table (drop first to ensure clean state)
         try (Connection c = getSourceConnection();
                 Statement st = c.createStatement()) {
             st.executeUpdate("DROP TABLE IF EXISTS t_order");
@@ -163,31 +56,14 @@ public class SchemaEvolutionIT {
 
     @After
     public void tearDown() {
-        if (flinkJobThread != null) {
-            // 先给管道时间自然结束，不要立即打断
-            try {
-                flinkJobThread.join(15000);
-            } catch (InterruptedException ignored) {
-            }
-            // 如果还没结束，再强制打断
-            if (flinkJobThread.isAlive()) {
-                flinkJobThread.interrupt();
-                try {
-                    flinkJobThread.join(5000);
-                } catch (InterruptedException ignored) {
-                }
-            }
-        }
-        if (sourceContainer != null) sourceContainer.stop();
-        if (sinkContainer != null) sinkContainer.stop();
+        stopMysqlContainers();
     }
 
     @Test
     public void testSyncWithAddColumn() throws Exception {
-        startFlinkPipeline();
+        startFlinkPipeline("schema-evolution-it");
         waitForCdcReady();
 
-        // Insert initial data AFTER pipeline is running (binlog path)
         try (Connection c = getSourceConnection();
                 Statement st = c.createStatement()) {
             st.executeUpdate(
@@ -201,15 +77,12 @@ public class SchemaEvolutionIT {
         assertSinkProduct("sink_t_order", 2, "phone");
         LOG.info("=== testSyncWithAddColumn: initial data synced ===");
 
-        // DDL: ADD COLUMN `discount`
         try (Connection c = getSourceConnection();
                 Statement st = c.createStatement()) {
             st.executeUpdate("ALTER TABLE t_order ADD COLUMN discount DECIMAL(10,2) DEFAULT 0.00");
         }
-        LOG.info("DDL executed: ADD COLUMN discount");
         TimeUnit.SECONDS.sleep(5);
 
-        // Insert row with new column
         try (Connection c = getSourceConnection();
                 Statement st = c.createStatement()) {
             st.executeUpdate(
@@ -219,15 +92,14 @@ public class SchemaEvolutionIT {
 
         waitForSinkRowCount("sink_t_order", 3, 60);
         assertSinkProduct("sink_t_order", 3, "tablet");
-        LOG.info("=== Phase 2 PASSED: ADD COLUMN + new data synced ===");
+        LOG.info("=== testSyncWithAddColumn PASSED ===");
     }
 
     @Test
     public void testSyncWithModifyColumn() throws Exception {
-        startFlinkPipeline();
+        startFlinkPipeline("schema-evolution-it");
         waitForCdcReady();
 
-        // Insert initial data AFTER pipeline is running
         try (Connection c = getSourceConnection();
                 Statement st = c.createStatement()) {
             st.executeUpdate(
@@ -237,14 +109,11 @@ public class SchemaEvolutionIT {
         }
 
         waitForSinkRowCount("sink_t_order", 2, 60);
-        LOG.info("=== testSyncWithModifyColumn: initial data synced ===");
 
-        // DDL: MODIFY COLUMN `amount` to DOUBLE
         try (Connection c = getSourceConnection();
                 Statement st = c.createStatement()) {
             st.executeUpdate("ALTER TABLE t_order MODIFY COLUMN amount DOUBLE");
         }
-        LOG.info("DDL executed: MODIFY COLUMN amount -> DOUBLE");
         TimeUnit.SECONDS.sleep(5);
 
         try (Connection c = getSourceConnection();
@@ -256,15 +125,14 @@ public class SchemaEvolutionIT {
 
         waitForSinkRowCount("sink_t_order", 3, 60);
         assertSinkProduct("sink_t_order", 3, "monitor");
-        LOG.info("=== Phase 2 PASSED: MODIFY COLUMN + data synced ===");
+        LOG.info("=== testSyncWithModifyColumn PASSED ===");
     }
 
     @Test
     public void testSyncWithDropAndReAdd() throws Exception {
-        startFlinkPipeline();
+        startFlinkPipeline("schema-evolution-it");
         waitForCdcReady();
 
-        // Insert initial data AFTER pipeline is running
         try (Connection c = getSourceConnection();
                 Statement st = c.createStatement()) {
             st.executeUpdate(
@@ -274,20 +142,15 @@ public class SchemaEvolutionIT {
         }
 
         waitForSinkRowCount("sink_t_order", 2, 60);
-        LOG.info("=== testSyncWithDropAndReAdd: initial data synced ===");
 
-        // Drop then re-add a column
         try (Connection c = getSourceConnection();
                 Statement st = c.createStatement()) {
             st.executeUpdate("ALTER TABLE t_order DROP COLUMN amount");
             TimeUnit.SECONDS.sleep(10);
             st.executeUpdate("ALTER TABLE t_order ADD COLUMN amount DECIMAL(10,2) DEFAULT 0.00");
         }
-        LOG.info("DDL executed: DROP + RE-ADD amount column");
-        // Extra delay for CDC binlog reader to fully recover after DDL
         TimeUnit.SECONDS.sleep(15);
 
-        // Retry INSERT up to 3 times with delays
         for (int attempt = 1; attempt <= 3; attempt++) {
             try (Connection c = getSourceConnection();
                     Statement st = c.createStatement()) {
@@ -295,7 +158,6 @@ public class SchemaEvolutionIT {
                         "INSERT IGNORE INTO t_order (id, product, amount, create_time) "
                                 + "VALUES (3, 'keyboard', 199.00, NOW())");
             }
-            LOG.info("INSERT attempt {} succeeded", attempt);
             TimeUnit.SECONDS.sleep(5);
             try (Connection c = getSinkConnection();
                     Statement st = c.createStatement();
@@ -310,67 +172,11 @@ public class SchemaEvolutionIT {
 
         waitForSinkRowCount("sink_t_order", 3, 60);
         assertSinkProduct("sink_t_order", 3, "keyboard");
-        LOG.info("=== Phase 2 PASSED: DROP + RE-ADD column synced ===");
+        LOG.info("=== testSyncWithDropAndReAdd PASSED ===");
     }
 
     // ---- helpers ----
 
-    private void startFlinkPipeline() {
-        env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
-        env.setParallelism(1);
-        env.enableCheckpointing(2000);
-        tEnv = StreamTableEnvironment.create(env);
-        tEnv.getConfig()
-                .getConfiguration()
-                .setString("pipeline.name", "schema-evolution-it-" + System.currentTimeMillis());
-
-        Map<String, String> args = new HashMap<>();
-        args.put("hostname", sourceContainer.getHost());
-        args.put("port", String.valueOf(sourceContainer.getMappedPort(3306)));
-        args.put("username", "root");
-        args.put("password", "root");
-        args.put("databaseName", SOURCE_DB);
-        args.put("tableList", SOURCE_DB + ".*");
-        args.put("sinkUrl", sinkUrl);
-        args.put("sinkUsername", "root");
-        args.put("sinkPassword", "root");
-        args.put("serverTimeZone", "UTC");
-        args.put("setParallelism", "1");
-        args.put("cdcSourceName", "mysql-cdc-sit");
-
-        flinkJobThread =
-                new Thread(
-                        () -> {
-                            try {
-                                new FlinkSqlWDS().handle(toArgs(args), env, tEnv);
-                            } catch (Exception e) {
-                                LOG.error("Flink pipeline failed", e);
-                            }
-                        },
-                        "flink-wds-it");
-        flinkJobThread.setDaemon(true);
-        flinkJobThread.start();
-
-        // Give pipeline time to start and discover existing tables
-        try {
-            TimeUnit.SECONDS.sleep(8);
-        } catch (InterruptedException ignored) {
-        }
-    }
-
-    private Connection getSourceConnection() throws SQLException {
-        return DriverManager.getConnection(sourceUrl, "root", "root");
-    }
-
-    private Connection getSinkConnection() throws SQLException {
-        return DriverManager.getConnection(sinkUrl, "root", "root");
-    }
-
-    /**
-     * Wait until the CDC pipeline's bootstrap has created the sink table, then give the binlog
-     * reader extra time to fully connect.
-     */
     @SuppressWarnings("BusyWait")
     private void waitForCdcReady() throws Exception {
         long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
@@ -382,45 +188,18 @@ public class SchemaEvolutionIT {
                                             "SELECT COUNT(*) FROM " + SINK_DB + ".sink_t_order")) {
                 if (rs.next()) {
                     LOG.info("CDC pipeline ready — sink_t_order exists, waiting for binlog reader");
-                    // Extra wait for binlog reader to fully initialize
                     TimeUnit.SECONDS.sleep(10);
                     return;
                 }
             } catch (Exception ignored) {
-                // table not yet created by bootstrap
             }
             Thread.sleep(1000);
         }
         LOG.warn("Timed out waiting for sink_t_order to appear — proceeding anyway");
     }
 
-    @SuppressWarnings("BusyWait")
-    private void waitForSinkRowCount(String table, int expected, int timeoutSeconds)
-            throws Exception {
-        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds);
-        int count = 0;
-        while (System.nanoTime() < deadline) {
-            try (Connection c = getSinkConnection();
-                    Statement st = c.createStatement()) {
-                try (ResultSet rs =
-                        st.executeQuery("SELECT COUNT(*) FROM " + SINK_DB + "." + table)) {
-                    if (rs.next()) {
-                        count = rs.getInt(1);
-                        if (count >= expected) return;
-                    }
-                }
-            } catch (Exception ignored) {
-                // table may not exist yet
-            }
-            Thread.sleep(2000);
-        }
-        assertTrue(
-                "Expected at least " + expected + " rows in " + table + ", got " + count,
-                count >= expected);
-    }
-
     private void assertSinkProduct(String table, int id, String expectedProduct)
-            throws SQLException {
+            throws java.sql.SQLException {
         try (Connection c = getSinkConnection();
                 Statement st = c.createStatement();
                 ResultSet rs =
@@ -434,15 +213,5 @@ public class SchemaEvolutionIT {
             assertTrue("row id=" + id + " should exist", rs.next());
             assertEquals("product mismatch for id=" + id, expectedProduct, rs.getString(1));
         }
-    }
-
-    private static String[] toArgs(Map<String, String> m) {
-        String[] out = new String[m.size() * 2];
-        int i = 0;
-        for (Map.Entry<String, String> e : m.entrySet()) {
-            out[i++] = "--" + e.getKey();
-            out[i++] = e.getValue();
-        }
-        return out;
     }
 }

--- a/e2e-tests/src/test/java/io/sophiadata/flink/sync/WholeDatabaseSyncIT.java
+++ b/e2e-tests/src/test/java/io/sophiadata/flink/sync/WholeDatabaseSyncIT.java
@@ -18,37 +18,15 @@
 
 package io.sophiadata.flink.sync;
 
-import org.apache.flink.api.common.RuntimeExecutionMode;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
-import org.apache.flink.test.util.MiniClusterWithClientResource;
-
-import io.sophiadata.flink.utils.MySqlContainer;
-import io.sophiadata.flink.utils.MySqlVersion;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * End-to-end integration test for whole-database CDC sync.
@@ -56,109 +34,13 @@ import static org.junit.Assert.assertTrue;
  * <p>Spins up two MySQL 8.0 containers (source + sink), runs the FlinkSqlWDS pipeline, inserts data
  * into the source, and verifies that INSERT / UPDATE / DELETE operations are correctly synced to
  * the sink database with {@code sink_} prefix table names.
- *
- * <p>This test specifically covers the bug where SharedSchemaState serialization across Flink
- * operators caused schemas to be empty on the TaskManager side, resulting in all records being
- * silently skipped.
  */
-public class WholeDatabaseSyncIT {
-
-    private static final Logger LOG = LoggerFactory.getLogger(WholeDatabaseSyncIT.class);
-
-    private static final String SOURCE_DB = "flink_source";
-    private static final String SINK_DB = "flink_sink";
-
-    @Rule
-    public MiniClusterWithClientResource miniClusterResource =
-            new MiniClusterWithClientResource(
-                    new MiniClusterResourceConfiguration.Builder()
-                            .setNumberTaskManagers(1)
-                            .setNumberSlotsPerTaskManager(1)
-                            .setConfiguration(createMiniClusterConfig())
-                            .build());
-
-    private static Configuration createMiniClusterConfig() {
-        Configuration config = new Configuration();
-        config.set(TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.ofMebiBytes(512));
-        config.set(TaskManagerOptions.TASK_OFF_HEAP_MEMORY, MemorySize.ofMebiBytes(128));
-        config.set(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY, MemorySize.ofMebiBytes(256));
-        config.set(TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY, MemorySize.ofMebiBytes(64));
-        return config;
-    }
-
-    private JdbcDatabaseContainer<?> sourceContainer;
-    private JdbcDatabaseContainer<?> sinkContainer;
-
-    private String sourceUrl;
-    private String sinkUrl;
-    private String sourceHost;
-    private int sourcePort;
-
-    private StreamExecutionEnvironment env;
-    private StreamTableEnvironment tEnv;
-    private Thread flinkJobThread;
+public class WholeDatabaseSyncIT extends AbstractMysqlSyncIT {
 
     @Before
     public void setUp() throws Exception {
-        // Source: MySQL 8.0 with ROW binlog for CDC
-        sourceContainer =
-                new MySqlContainer(MySqlVersion.V8_0)
-                        .withDatabaseName(SOURCE_DB)
-                        .withUsername("root")
-                        .withPassword("root")
-                        .withConfigurationOverride("docker.cnf");
-        sourceContainer.start();
+        startMysqlContainers();
 
-        // Sink: plain MySQL
-        sinkContainer =
-                new MySqlContainer(MySqlVersion.V8_0)
-                        .withDatabaseName(SINK_DB)
-                        .withUsername("root")
-                        .withPassword("root");
-        sinkContainer.start();
-
-        sourceHost = sourceContainer.getHost();
-        sourcePort = sourceContainer.getMappedPort(3306);
-        sourceUrl =
-                "jdbc:mysql://"
-                        + sourceHost
-                        + ":"
-                        + sourcePort
-                        + "/"
-                        + SOURCE_DB
-                        + "?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC";
-        sinkUrl =
-                "jdbc:mysql://"
-                        + sinkContainer.getHost()
-                        + ":"
-                        + sinkContainer.getMappedPort(3306)
-                        + "/"
-                        + SINK_DB
-                        + "?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC";
-
-        LOG.info("Source MySQL: {}", sourceUrl);
-        LOG.info("Sink MySQL: {}", sinkUrl);
-
-        // Create CDC user with replication privileges on source
-        try (Connection c =
-                        DriverManager.getConnection(
-                                "jdbc:mysql://"
-                                        + sourceHost
-                                        + ":"
-                                        + sourcePort
-                                        + "/?useSSL=false&allowPublicKeyRetrieval=true",
-                                "root",
-                                "root");
-                Statement st = c.createStatement()) {
-            st.executeUpdate(
-                    "CREATE USER IF NOT EXISTS 'cdc_user'@'%' IDENTIFIED BY 'cdc_password'");
-            st.executeUpdate(
-                    "GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, "
-                            + "REPLICATION CLIENT, LOCK TABLES ON *.* TO 'cdc_user'@'%'");
-            st.executeUpdate("FLUSH PRIVILEGES");
-        }
-
-        // Create source tables
         try (Connection c = getSourceConnection();
                 Statement st = c.createStatement()) {
             st.executeUpdate("DROP TABLE IF EXISTS orders");
@@ -183,31 +65,14 @@ public class WholeDatabaseSyncIT {
 
     @After
     public void tearDown() {
-        if (flinkJobThread != null) {
-            try {
-                flinkJobThread.join(15000);
-            } catch (InterruptedException ignored) {
-            }
-            if (flinkJobThread.isAlive()) {
-                flinkJobThread.interrupt();
-                try {
-                    flinkJobThread.join(5000);
-                } catch (InterruptedException ignored) {
-                }
-            }
-        }
-        if (sourceContainer != null) sourceContainer.stop();
-        if (sinkContainer != null) sinkContainer.stop();
+        stopMysqlContainers();
     }
-
-    // ---- Test cases ----
 
     @Test
     public void testInsertSync() throws Exception {
-        startFlinkPipeline();
+        startFlinkPipeline("whole-db-sync-it");
         waitForSinkTable("sink_users", 60);
 
-        // Insert data into source
         try (Connection c = getSourceConnection();
                 Statement st = c.createStatement()) {
             st.executeUpdate(
@@ -224,10 +89,9 @@ public class WholeDatabaseSyncIT {
 
     @Test
     public void testUpdateSync() throws Exception {
-        startFlinkPipeline();
+        startFlinkPipeline("whole-db-sync-it");
         waitForSinkTable("sink_users", 60);
 
-        // Step 1: Insert, then wait for it to sync before updating
         try (Connection c = getSourceConnection();
                 Statement st = c.createStatement()) {
             st.executeUpdate(
@@ -236,19 +100,17 @@ public class WholeDatabaseSyncIT {
         waitForSinkRowCount("sink_users", 1, 60);
         TimeUnit.SECONDS.sleep(3);
 
-        // Step 2: Update
         try (Connection c = getSourceConnection();
                 Statement st = c.createStatement()) {
             st.executeUpdate("UPDATE users SET age = 26 WHERE name = 'Alice'");
         }
 
-        // Step 3: Wait for the sink to reflect the update
         long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(60);
         int age = 0;
         while (System.nanoTime() < deadline) {
-            try (Connection c = getSinkConnection();
+            try (java.sql.Connection c = getSinkConnection();
                     Statement st = c.createStatement();
-                    ResultSet rs =
+                    java.sql.ResultSet rs =
                             st.executeQuery(
                                     "SELECT age FROM "
                                             + SINK_DB
@@ -266,10 +128,9 @@ public class WholeDatabaseSyncIT {
 
     @Test
     public void testDeleteSync() throws Exception {
-        startFlinkPipeline();
+        startFlinkPipeline("whole-db-sync-it");
         waitForSinkTable("sink_users", 60);
 
-        // Step 1: Insert two rows, wait for sync
         try (Connection c = getSourceConnection();
                 Statement st = c.createStatement()) {
             st.executeUpdate(
@@ -280,19 +141,17 @@ public class WholeDatabaseSyncIT {
         waitForSinkRowCount("sink_users", 2, 60);
         TimeUnit.SECONDS.sleep(3);
 
-        // Step 2: Delete Alice
         try (Connection c = getSourceConnection();
                 Statement st = c.createStatement()) {
             st.executeUpdate("DELETE FROM users WHERE name = 'Alice'");
         }
 
-        // Step 3: Wait for sink to reflect the delete
         long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(60);
         int remaining = 2;
         while (System.nanoTime() < deadline) {
-            try (Connection c = getSinkConnection();
+            try (java.sql.Connection c = getSinkConnection();
                     Statement st = c.createStatement();
-                    ResultSet rs =
+                    java.sql.ResultSet rs =
                             st.executeQuery("SELECT COUNT(*) FROM " + SINK_DB + ".sink_users")) {
                 if (rs.next()) {
                     remaining = rs.getInt(1);
@@ -308,11 +167,10 @@ public class WholeDatabaseSyncIT {
 
     @Test
     public void testMultipleTableSync() throws Exception {
-        startFlinkPipeline();
+        startFlinkPipeline("whole-db-sync-it");
         waitForSinkTable("sink_users", 60);
         waitForSinkTable("sink_orders", 60);
 
-        // Insert into both tables
         try (Connection c = getSourceConnection();
                 Statement st = c.createStatement()) {
             st.executeUpdate(
@@ -331,7 +189,6 @@ public class WholeDatabaseSyncIT {
 
     @Test
     public void testPreExistingDataSync() throws Exception {
-        // Insert data BEFORE starting the pipeline (tests bootstrap path)
         try (Connection c = getSourceConnection();
                 Statement st = c.createStatement()) {
             st.executeUpdate(
@@ -341,10 +198,9 @@ public class WholeDatabaseSyncIT {
                             + "('Charlie', 'charlie@example.com', 35)");
         }
 
-        startFlinkPipeline();
+        startFlinkPipeline("whole-db-sync-it");
         waitForSinkTable("sink_users", 60);
 
-        // Pre-existing data should be synced via snapshot
         waitForSinkRowCount("sink_users", 3, 60);
         assertSinkRow("sink_users", "name", "Alice");
         assertSinkRow("sink_users", "name", "Bob");
@@ -352,126 +208,7 @@ public class WholeDatabaseSyncIT {
         LOG.info("=== testPreExistingDataSync PASSED ===");
     }
 
-    // ---- Helpers ----
-
-    private void startFlinkPipeline() {
-        env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
-        env.setParallelism(1);
-        env.enableCheckpointing(2000);
-        tEnv = StreamTableEnvironment.create(env);
-        tEnv.getConfig()
-                .getConfiguration()
-                .setString("pipeline.name", "whole-db-sync-it-" + System.currentTimeMillis());
-
-        Map<String, String> args = new HashMap<>();
-        args.put("hostname", sourceHost);
-        args.put("port", String.valueOf(sourcePort));
-        args.put("username", "root");
-        args.put("password", "root");
-        args.put("databaseName", SOURCE_DB);
-        args.put("tableList", SOURCE_DB + ".*");
-        args.put("sinkUrl", sinkUrl);
-        args.put("sinkUsername", "root");
-        args.put("sinkPassword", "root");
-        args.put("serverTimeZone", "UTC");
-        args.put("setParallelism", "1");
-        args.put("cdcSourceName", "mysql-cdc-e2e");
-
-        flinkJobThread =
-                new Thread(
-                        () -> {
-                            try {
-                                new FlinkSqlWDS().handle(toArgs(args), env, tEnv);
-                            } catch (Exception e) {
-                                LOG.error("Flink pipeline failed", e);
-                            }
-                        },
-                        "flink-wds-e2e");
-        flinkJobThread.setDaemon(true);
-        flinkJobThread.start();
-    }
-
-    private Connection getSourceConnection() throws SQLException {
-        return DriverManager.getConnection(sourceUrl, "root", "root");
-    }
-
-    private Connection getSinkConnection() throws SQLException {
-        return DriverManager.getConnection(sinkUrl, "root", "root");
-    }
-
-    @SuppressWarnings("BusyWait")
-    private void waitForSinkTable(String table, int timeoutSeconds) throws Exception {
-        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds);
-        while (System.nanoTime() < deadline) {
-            try (Connection c = getSinkConnection();
-                    ResultSet rs =
-                            c.createStatement()
-                                    .executeQuery(
-                                            "SELECT COUNT(*) FROM " + SINK_DB + "." + table)) {
-                if (rs.next()) {
-                    LOG.info("Sink table {} is ready", table);
-                    TimeUnit.SECONDS.sleep(5);
-                    return;
-                }
-            } catch (Exception ignored) {
-                // table not yet created by bootstrap
-            }
-            Thread.sleep(1000);
-        }
-        assertTrue("Timed out waiting for sink table " + table, false);
-    }
-
-    @SuppressWarnings("BusyWait")
-    private void waitForSinkRowCount(String table, int expected, int timeoutSeconds)
-            throws Exception {
-        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds);
-        int count = 0;
-        while (System.nanoTime() < deadline) {
-            try (Connection c = getSinkConnection();
-                    Statement st = c.createStatement();
-                    ResultSet rs =
-                            st.executeQuery("SELECT COUNT(*) FROM " + SINK_DB + "." + table)) {
-                if (rs.next()) {
-                    count = rs.getInt(1);
-                    if (count >= expected) return;
-                }
-            } catch (Exception ignored) {
-                // table may not exist yet
-            }
-            Thread.sleep(2000);
-        }
-        assertTrue(
-                "Expected at least " + expected + " rows in " + table + ", got " + count,
-                count >= expected);
-    }
-
-    private void assertSinkRow(String table, String column, String value) throws SQLException {
-        try (Connection c = getSinkConnection();
-                Statement st = c.createStatement();
-                ResultSet rs =
-                        st.executeQuery(
-                                "SELECT COUNT(*) FROM "
-                                        + SINK_DB
-                                        + "."
-                                        + table
-                                        + " WHERE "
-                                        + column
-                                        + " = '"
-                                        + value
-                                        + "'")) {
-            assertTrue("row with " + column + "=" + value + " should exist", rs.next());
-            assertTrue("expected at least 1 row with " + column + "=" + value, rs.getInt(1) >= 1);
-        }
-    }
-
-    private static String[] toArgs(Map<String, String> m) {
-        String[] out = new String[m.size() * 2];
-        int i = 0;
-        for (Map.Entry<String, String> e : m.entrySet()) {
-            out[i++] = "--" + e.getKey();
-            out[i++] = e.getValue();
-        }
-        return out;
+    private void assertEquals(String msg, int expected, int actual) {
+        org.junit.Assert.assertEquals(msg, expected, actual);
     }
 }


### PR DESCRIPTION
## Summary
- Extract AbstractMysqlSyncIT base class (~200 lines of shared code)
- Add CDBBatchSink unit tests (Record construction, invoke filtering)
- Add SchemaEvolver concurrent event processing test
- Unit tests: 67 → 72