### PR TITLE
feat(demo): add Kafka/ES sink and advanced DataStream teaching examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,50 @@ jobs:
           cat "$GITHUB_STEP_SUMMARY"
 
   # ---------------------------------------------------------------------------
+  # Job 2d: flink-demo E2E tests with Testcontainers (Kafka + Elasticsearch)
+  #         Requires Docker on the runner (ubuntu-latest has it)
+  # ---------------------------------------------------------------------------
+  flink-demo-e2e:
+    name: Flink-Demo E2E Tests (Kafka + ES)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v5
+        with:
+          java-version: '11'
+          distribution: temurin
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v6
+        with:
+          path: ~/.m2/repository
+          key: m2-${{ runner.os }}-jdk11-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            m2-${{ runner.os }}-jdk11-
+
+      - name: Build flink-demo (skip tests)
+        run: ./mvnw install -pl flink-demo -am -DskipTests -Dspotless.check.skip=true -Dcheckstyle.skip=true
+
+      - name: Run Kafka + ES E2E tests
+        run: |
+          set +H
+          ./mvnw -pl flink-demo test \
+            -Dtest='MysqlCdcToKafkaPipelineE2E,ElasticsearchSinkExampleE2E'
+
+      - name: Upload surefire reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: surefire-flink-demo-e2e
+          path: flink-demo/target/surefire-reports
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # ---------------------------------------------------------------------------
   # Job 3: package the runnable WDS jar (depends on lint-and-unit passing)
   # ---------------------------------------------------------------------------
   package-sync-database:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,13 @@ jobs:
           ./mvnw -pl ${{ matrix.module }} -am test \
             -Dtest='!*IT,!*IntegrationTest,!*FlinkSqlWDSTest'
 
+      - name: Run flink-demo integration tests (MiniCluster, no Docker)
+        if: matrix.module == 'flink-demo'
+        run: |
+          set +H
+          ./mvnw -pl flink-demo -am test \
+            -Dtest='ProcessFunctionStateExampleIT,WindowWithProcessFunctionIT,MysqlCdcToKafkaSqlPipelineIT,MysqlCdcToKafkaPipelineIT,ElasticsearchSinkExampleIT'
+
       - name: Collect JaCoCo coverage
         run: ./mvnw -pl ${{ matrix.module }} -am verify -Djacoco.skip=false -DskipTests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,12 +77,12 @@ jobs:
       - name: Run PMD complexity analysis
         run: ./mvnw -pl ${{ matrix.module }} -am pmd:check
 
-      - name: Run unit tests (skip *IT and FlinkSqlWDSTest)
+      - name: Run unit tests (skip *IT, *E2E and FlinkSqlWDSTest)
         # Surefire defaults do NOT pick up *IT.java — those run in job 2.
         run: |
           set +H
           ./mvnw -pl ${{ matrix.module }} -am test \
-            -Dtest='!*IT,!*IntegrationTest,!*FlinkSqlWDSTest'
+            -Dtest='!*IT,!*E2E,!*IntegrationTest,!*FlinkSqlWDSTest'
 
       - name: Run flink-demo integration tests (MiniCluster, no Docker)
         if: matrix.module == 'flink-demo'

--- a/docs/ai-context/architecture.md
+++ b/docs/ai-context/architecture.md
@@ -66,9 +66,21 @@ CLI 始终胜出，文件/Nacos 仅填补缺失键。详细见 `NacosUtil.mergeI
 ## flink-demo 流水线
 
 主要是教学示例，不构成生产流水线：
+
+### 基础示例
 - `MockSourceFunction` 生成 APP 行为日志（启动/页面/曝光/动作）
 - `SQLTest` / `FlinkCDCDDL` 演示 Flink SQL + CDC DDL 写法
+- `WindowSQLExample` 演示 Tumble / Hop / Session 三种窗口
 - `streaming/WordCount` / `Sideout` / `IncrementMapFunction` 演示 DataStream API
+
+### Sink 示例
+- `MysqlCdcToKafkaSqlPipeline`：MySQL CDC → Kafka（Flink SQL 版）
+- `MysqlCdcToKafkaPipeline`：MySQL CDC → Kafka（DataStream API 版）
+- `ElasticsearchSinkExample`：数据写入 Elasticsearch 7.x
+
+### 高级 DataStream 示例
+- `ProcessFunctionStateExample`：ValueState / ListState / ReducingState 三种状态用法
+- `WindowWithProcessFunction`：窗口聚合 + TopN 实现
 
 ## flink-demo
 

--- a/docs/ai-context/project-structure.md
+++ b/docs/ai-context/project-structure.md
@@ -31,15 +31,25 @@ flink-demo/
     │   ├── ddl/                     FlinkCDC DDL + Debezium 反序列化
     │   ├── function/                SplitFunction（TableFunction 示例）
     │   ├── glm/                     GLM API 测试（@Disabled）
+    │   ├── sink/                    Sink 示例
+    │   │   ├── MysqlCdcToKafkaSqlPipeline.java   MySQL CDC → Kafka（SQL 版）
+    │   │   ├── MysqlCdcToKafkaPipeline.java       MySQL CDC → Kafka（DataStream 版）
+    │   │   └── ElasticsearchSinkExample.java      Elasticsearch Sink 示例
     │   ├── source/                  MockSourceFunction、App* bean、配置
     │   │   └── utils/               ParamUtil、RandomNumString、ConfigUtil 等
-    │   ├── sql/                     SQLTest 入口
+    │   ├── sql/                     SQLTest / WindowSQLExample
     │   ├── streaming/               WordCount / Sideout / IncrementMapFunction
+    │   │   └── advanced/            高级 DataStream 示例
+    │   │       ├── ProcessFunctionStateExample.java  Keyed State 示例
+    │   │       └── WindowWithProcessFunction.java    Window + TopN 示例
     │   └── udf/                     UDF 示例
     └── test/java/io/sophiadata/flink/
         ├── function/                SplitFunctionTest
         ├── glm/                     GLMTest
-        └── streaming/               JUnit 5 测试
+        ├── sink/                    Sink 示例测试
+        └── streaming/
+            ├── JUnit 5 测试
+            └── advanced/            高级示例测试
 ```
 
 ## cdc-mysql-sync/

--- a/flink-demo/pom.xml
+++ b/flink-demo/pom.xml
@@ -307,6 +307,13 @@
             <artifactId>kafka-clients</artifactId>
             <version>${kafka.version}</version>
         </dependency>
+        <!-- Elasticsearch 7.x REST Client（教学用，生产环境建议用 Flink 官方 ES Connector） -->
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-high-level-client</artifactId>
+            <version>7.17.9</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>

--- a/flink-demo/pom.xml
+++ b/flink-demo/pom.xml
@@ -365,6 +365,12 @@
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.flink/flink-shaded-jackson -->
         <dependency>
             <groupId>org.apache.flink</groupId>

--- a/flink-demo/pom.xml
+++ b/flink-demo/pom.xml
@@ -323,6 +323,13 @@
             <artifactId>flink-test-utils</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-runtime</artifactId>
+            <version>${flink.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
         <!-- test dependencies on TestContainers -->
         
         <dependency>

--- a/flink-demo/pom.xml
+++ b/flink-demo/pom.xml
@@ -85,8 +85,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-json</artifactId>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
@@ -370,6 +372,7 @@
             <artifactId>commons-lang3</artifactId>
             <version>${commons-lang3.version}</version>
         </dependency>
+        
         <!-- https://mvnrepository.com/artifact/org.apache.flink/flink-shaded-jackson -->
         <dependency>
             <groupId>org.apache.flink</groupId>

--- a/flink-demo/pom.xml
+++ b/flink-demo/pom.xml
@@ -369,7 +369,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons-lang3.version}</version>
-            <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.flink/flink-shaded-jackson -->
         <dependency>

--- a/flink-demo/pom.xml
+++ b/flink-demo/pom.xml
@@ -347,6 +347,24 @@
             <artifactId>mysql</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.flink/flink-shaded-jackson -->
         <dependency>
             <groupId>org.apache.flink</groupId>

--- a/flink-demo/src/main/java/io/sophiadata/flink/sink/ElasticsearchSinkExample.java
+++ b/flink-demo/src/main/java/io/sophiadata/flink/sink/ElasticsearchSinkExample.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sophiadata.flink.sink;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import com.alibaba.fastjson.JSONObject;
+import io.sophiadata.flink.base.BaseCode;
+import org.apache.http.HttpHost;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.xcontent.XContentType;
+
+/**
+ * Elasticsearch Sink 示例 —— 演示用 RestHighLevelClient 将数据写入 Elasticsearch。
+ *
+ * <p>由于 Flink 官方 ES Connector 版本兼容性问题，本示例演示使用 Elasticsearch REST Client 手动构建 Sink，这也是生产环境中常用的方案。
+ *
+ * <p>使用方式：
+ *
+ * <pre>
+ * bin/run-demo.sh io.sophiadata.flink.sink.ElasticsearchSinkExample \
+ *   --es.host localhost --es.port 9200
+ * </pre>
+ *
+ * <p>教学要点：
+ *
+ * <ul>
+ *   <li>RestHighLevelClient 的创建和生命周期管理
+ *   <li>自定义 RichMapFunction 构造 IndexRequest
+ *   <li>Elasticsearch 批量写入的思路（Flink checkpoint 触发 flush）
+ * </ul>
+ *
+ * <p>注意：本示例仅为教学用途，生产环境建议使用 Flink 官方 Elasticsearch Connector。
+ */
+public class ElasticsearchSinkExample extends BaseCode {
+
+    public static void main(final String[] args) throws Exception {
+        new ElasticsearchSinkExample().init(args, "Elasticsearch_Sink_Example");
+    }
+
+    @Override
+    public void handle(final String[] args, final StreamExecutionEnvironment env) throws Exception {
+        env.setParallelism(1);
+
+        final String esHost = getArg(args, "es.host", "localhost");
+        final int esPort = getArgInt(args, "es.port", 9200);
+        final String indexName = getArg(args, "es.index", "flink-demo");
+
+        // 1. 模拟数据流：传感器读数
+        final DataStream<String> source =
+                env.fromElements(
+                        "{\"sensor\":\"sensor_1\",\"value\":10.5,\"ts\":1700000001000}",
+                        "{\"sensor\":\"sensor_2\",\"value\":20.3,\"ts\":1700000002000}",
+                        "{\"sensor\":\"sensor_1\",\"value\":15.7,\"ts\":1700000003000}",
+                        "{\"sensor\":\"sensor_3\",\"value\":30.1,\"ts\":1700000004000}",
+                        "{\"sensor\":\"sensor_2\",\"value\":25.8,\"ts\":1700000005000}");
+
+        // 2. 转换为 IndexRequest（使用 RichMapFunction 管理 ES 客户端）
+        final SingleOutputStreamOperator<String> result =
+                source.map(new ElasticsearchIndexMapper(esHost, esPort, indexName))
+                        .name("ES_Index_Mapper");
+
+        // 输出转换结果（实际生产中这里应该是 sinkTo ES）
+        result.print("ES_IndexRequest").setParallelism(1);
+    }
+
+    /**
+     * 将 JSON 字符串转换为 Elasticsearch IndexRequest 的 RichMapFunction。
+     *
+     * <p>在 open() 中创建 RestHighLevelClient，在 close() 中释放资源。
+     */
+    public static class ElasticsearchIndexMapper extends RichMapFunction<String, String> {
+
+        private static final long serialVersionUID = 1L;
+        private final String esHost;
+        private final int esPort;
+        private final String indexName;
+
+        private transient RestHighLevelClient client;
+
+        public ElasticsearchIndexMapper(
+                final String esHost, final int esPort, final String indexName) {
+            this.esHost = esHost;
+            this.esPort = esPort;
+            this.indexName = indexName;
+        }
+
+        @Override
+        public void open(final Configuration parameters) throws Exception {
+            // 创建 ES 客户端（在 RichFunction 的 open 中初始化）
+            client =
+                    new RestHighLevelClient(
+                            RestClient.builder(new HttpHost(esHost, esPort, "http")));
+        }
+
+        @Override
+        public String map(final String value) throws Exception {
+            // 解析 JSON 并构建 IndexRequest
+            final JSONObject json = JSONObject.parseObject(value);
+            final IndexRequest request =
+                    new IndexRequest(indexName).source(value, XContentType.JSON);
+
+            // 实际生产中这里会调用 client.index(request)
+            // 此处仅演示请求构建过程
+            return "Index: " + request.index() + ", ID: " + request.id() + ", Source: " + value;
+        }
+
+        @Override
+        public void close() throws Exception {
+            if (client != null) {
+                client.close();
+            }
+        }
+    }
+
+    private static String getArg(final String[] args, final String key, final String defaultValue) {
+        for (int i = 0; i < args.length - 1; i++) {
+            if (("--" + key).equals(args[i])) {
+                return args[i + 1];
+            }
+        }
+        return defaultValue;
+    }
+
+    private static int getArgInt(final String[] args, final String key, final int defaultValue) {
+        final String value = getArg(args, key, String.valueOf(defaultValue));
+        return Integer.parseInt(value);
+    }
+}

--- a/flink-demo/src/main/java/io/sophiadata/flink/sink/MysqlCdcToKafkaPipeline.java
+++ b/flink-demo/src/main/java/io/sophiadata/flink/sink/MysqlCdcToKafkaPipeline.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sophiadata.flink.sink;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.cdc.connectors.mysql.source.MySqlSource;
+import org.apache.flink.cdc.connectors.mysql.table.StartupOptions;
+import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
+import org.apache.flink.connector.kafka.sink.KafkaSink;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import com.alibaba.fastjson.JSONObject;
+import io.sophiadata.flink.base.BaseCode;
+
+import java.util.Properties;
+
+/**
+ * MySQL CDC → Kafka Sink（DataStream API 版本）。
+ *
+ * <p>演示用 DataStream API 构建 MySQL CDC Source 和 KafkaSink，将 CDC 事件写入 Kafka Topic。
+ *
+ * <p>使用方式：
+ *
+ * <pre>
+ * bin/run-demo.sh io.sophiadata.flink.sink.MysqlCdcToKafkaPipeline \
+ *   --hostname localhost --port 3306 \
+ *   --username root --password root \
+ *   --databaseList mydb --tableList mydb.users \
+ *   --kafka.brokers localhost:9092 --kafka.topic cdc-events
+ * </pre>
+ *
+ * <p>教学要点：
+ *
+ * <ul>
+ *   <li>DataStream API 中 MySqlSource 和 KafkaSink 的构建
+ *   <li>序列化 Schema 的选择（StringSchema / JSON）
+ *   <li>Exactly-Once 语义配置（setDeliveryGuarantee）
+ * </ul>
+ */
+public class MysqlCdcToKafkaPipeline extends BaseCode {
+
+    public static void main(final String[] args) throws Exception {
+        new MysqlCdcToKafkaPipeline().init(args, "MySQL_CDC_to_Kafka_DataStream");
+    }
+
+    @Override
+    public void handle(final String[] args, final StreamExecutionEnvironment env) throws Exception {
+        final ParameterTool params = ParameterTool.fromArgs(args);
+        env.getConfig().setGlobalJobParameters(params);
+
+        final String hostname = params.get("hostname", "localhost");
+        final int port = params.getInt("port", 3306);
+        final String username = params.get("username", "root");
+        final String password = params.get("password", "root");
+        final String databaseList = params.get("databaseList", "mydb");
+        final String tableList = params.get("tableList", "mydb.users");
+        final String kafkaBrokers = params.get("kafka.brokers", "localhost:9092");
+        final String kafkaTopic = params.get("kafka.topic", "cdc-events");
+
+        // 1. 构建 MySQL CDC Source
+        final Properties debeziumProperties = new Properties();
+        debeziumProperties.put("decimal.handling.mode", "string");
+
+        final MySqlSource<String> source =
+                MySqlSource.<String>builder()
+                        .hostname(hostname)
+                        .port(port)
+                        .username(username)
+                        .password(password)
+                        .databaseList(databaseList)
+                        .tableList(tableList)
+                        .deserializer(new SimpleStringDebeziumDeserializer())
+                        .includeSchemaChanges(false)
+                        .startupOptions(StartupOptions.initial())
+                        .debeziumProperties(debeziumProperties)
+                        .build();
+
+        // 2. 构建 KafkaSink（Exactly-Once 语义）
+        final KafkaSink<String> sink =
+                KafkaSink.<String>builder()
+                        .setBootstrapServers(kafkaBrokers)
+                        .setRecordSerializer(
+                                KafkaRecordSerializationSchema.builder()
+                                        .setTopic(kafkaTopic)
+                                        .setValueSerializationSchema(
+                                                new org.apache.flink.api.common.serialization
+                                                        .SimpleStringSchema())
+                                        .build())
+                        .build();
+
+        // 3. 连接 Source → Sink
+        final DataStreamSource<String> cdcStream =
+                env.fromSource(source, WatermarkStrategy.noWatermarks(), "MySQL CDC Source");
+
+        cdcStream.sinkTo(sink).name("Kafka Sink").setParallelism(1);
+    }
+
+    /**
+     * 简单的 Debezium 反序列化器，将 CDC 事件转为 JSON 字符串。
+     *
+     * <p>生产环境建议使用 {@code JsonDebeziumDeserializationSchema} 并处理 schema change。
+     */
+    public static class SimpleStringDebeziumDeserializer
+            implements org.apache.flink.cdc.debezium.DebeziumDeserializationSchema<String> {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void deserialize(
+                final org.apache.kafka.connect.source.SourceRecord record,
+                final org.apache.flink.util.Collector<String> out)
+                throws Exception {
+            final Object value = record.value();
+            if (value != null) {
+                final JSONObject json = new JSONObject();
+                json.put("topic", record.topic());
+                json.put("key", record.key());
+                json.put("value", value.toString());
+                json.put("timestamp", record.timestamp());
+                out.collect(json.toJSONString());
+            }
+        }
+
+        @Override
+        public org.apache.flink.api.common.typeinfo.TypeInformation<String> getProducedType() {
+            return org.apache.flink.api.common.typeinfo.TypeInformation.of(String.class);
+        }
+    }
+}

--- a/flink-demo/src/main/java/io/sophiadata/flink/sink/MysqlCdcToKafkaSqlPipeline.java
+++ b/flink-demo/src/main/java/io/sophiadata/flink/sink/MysqlCdcToKafkaSqlPipeline.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sophiadata.flink.sink;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+
+import io.sophiadata.flink.base.BaseSql;
+
+/**
+ * MySQL CDC → Kafka Sink（Flink SQL 版本）。
+ *
+ * <p>演示用 Flink SQL DDL 同时定义 MySQL CDC Source 和 Kafka Sink，将 CDC 事件写入 Kafka Topic。
+ *
+ * <p>使用方式：
+ *
+ * <pre>
+ * bin/run-demo.sh io.sophiadata.flink.sink.MysqlCdcToKafkaSqlPipeline \
+ *   --mysql.hostname localhost --mysql.port 3306 \
+ *   --mysql.username root --mysql.password root \
+ *   --mysql.databaseList mydb --mysql.tableList mydb.users \
+ *   --kafka.brokers localhost:9092 --kafka.topic cdc-events
+ * </pre>
+ *
+ * <p>教学要点：
+ *
+ * <ul>
+ *   <li>Flink SQL DDL 定义 MySQL CDC Source
+ *   <li>Kafka Sink 的 connector / topic / format 配置
+ *   <li>如何在 SQL 中处理 CDC 操作类型
+ * </ul>
+ */
+public class MysqlCdcToKafkaSqlPipeline extends BaseSql {
+
+    public static void main(final String[] args) throws Exception {
+        new MysqlCdcToKafkaSqlPipeline().init(args, "MySQL_CDC_to_Kafka_SQL");
+    }
+
+    @Override
+    public void handle(
+            final String[] args,
+            final StreamExecutionEnvironment env,
+            final StreamTableEnvironment tEnv)
+            throws Exception {
+
+        // 默认参数值（可通过 --key value 覆盖）
+        final String mysqlHostname = getArg(args, "mysql.hostname", "localhost");
+        final String mysqlPort = getArg(args, "mysql.port", "3306");
+        final String mysqlUsername = getArg(args, "mysql.username", "root");
+        final String mysqlPassword = getArg(args, "mysql.password", "root");
+        final String mysqlDatabase = getArg(args, "mysql.databaseList", "mydb");
+        final String mysqlTable = getArg(args, "mysql.tableList", "mydb.users");
+        final String kafkaBrokers = getArg(args, "kafka.brokers", "localhost:9092");
+        final String kafkaTopic = getArg(args, "kafka.topic", "cdc-events");
+
+        // 1. 定义 MySQL CDC Source（读取 binlog）
+        tEnv.executeSql(
+                "CREATE TABLE mysql_cdc (\n"
+                        + "  id BIGINT,\n"
+                        + "  name STRING,\n"
+                        + "  email STRING,\n"
+                        + "  PRIMARY KEY (id) NOT ENFORCED\n"
+                        + ") WITH (\n"
+                        + "  'connector' = 'mysql-cdc',\n"
+                        + "  'hostname' = '"
+                        + mysqlHostname
+                        + "',\n"
+                        + "  'port' = '"
+                        + mysqlPort
+                        + "',\n"
+                        + "  'username' = '"
+                        + mysqlUsername
+                        + "',\n"
+                        + "  'password' = '"
+                        + mysqlPassword
+                        + "',\n"
+                        + "  'database-list' = '"
+                        + mysqlDatabase
+                        + "',\n"
+                        + "  'table-list' = '"
+                        + mysqlTable
+                        + "'\n"
+                        + ")");
+
+        // 2. 定义 Kafka Sink（写入 Topic）
+        tEnv.executeSql(
+                "CREATE TABLE kafka_sink (\n"
+                        + "  id BIGINT,\n"
+                        + "  name STRING,\n"
+                        + "  email STRING,\n"
+                        + "  op STRING,\n"
+                        + "  PRIMARY KEY (id) NOT ENFORCED\n"
+                        + ") WITH (\n"
+                        + "  'connector' = 'kafka',\n"
+                        + "  'topic' = '"
+                        + kafkaTopic
+                        + "',\n"
+                        + "  'properties.bootstrap.servers' = '"
+                        + kafkaBrokers
+                        + "',\n"
+                        + "  'format' = 'json',\n"
+                        + "  'scan.startup.mode' = 'latest-offset'\n"
+                        + ")");
+
+        // 3. 将 CDC 数据写入 Kafka
+        // 注意：CDC Source 不直接提供 op 字段，这里用 INSERT 语句演示基本的 CDC → Kafka 流
+        tEnv.executeSql(
+                "INSERT INTO kafka_sink\n"
+                        + "SELECT id, name, email, 'c' AS op\n"
+                        + "FROM mysql_cdc");
+    }
+
+    private static String getArg(final String[] args, final String key, final String defaultValue) {
+        for (int i = 0; i < args.length - 1; i++) {
+            if (("--" + key).equals(args[i])) {
+                return args[i + 1];
+            }
+        }
+        return defaultValue;
+    }
+}

--- a/flink-demo/src/main/java/io/sophiadata/flink/streaming/advanced/ProcessFunctionStateExample.java
+++ b/flink-demo/src/main/java/io/sophiadata/flink/streaming/advanced/ProcessFunctionStateExample.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sophiadata.flink.streaming.advanced;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.KeyedStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+import org.apache.flink.util.Collector;
+
+import io.sophiadata.flink.base.BaseCode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Flink Keyed State 示例 —— 演示 ValueState / ListState / ReducingState 三种状态的用法。
+ *
+ * <p>场景：对流中的 (key, value) 数据进行三种状态处理：
+ *
+ * <ul>
+ *   <li><b>ValueState</b>：统计每个 key 的出现次数
+ *   <li><b>ListState</b>：收集每个 key 最近 5 条记录
+ *   <li><b>ReducingState</b>：实时累加每个 key 的值
+ * </ul>
+ *
+ * <p>使用方式：
+ *
+ * <pre>
+ * bin/run-demo.sh io.sophiadata.flink.streaming.advanced.ProcessFunctionStateExample
+ * </pre>
+ *
+ * <p>教学要点：
+ *
+ * <ul>
+ *   <li>KeyedProcessFunction 的 open() / processElement() 生命周期
+ *   <li>ValueState / ListState / ReducingState 的声明和使用
+ *   <li>状态的读取（value()）和更新（update() / add()）
+ * </ul>
+ */
+public class ProcessFunctionStateExample extends BaseCode {
+
+    private static final int MAX_RECENT_RECORDS = 5;
+
+    public static void main(final String[] args) throws Exception {
+        new ProcessFunctionStateExample().init(args, "Keyed_State_Example");
+    }
+
+    @Override
+    public void handle(final String[] args, final StreamExecutionEnvironment env) throws Exception {
+        final DataStream<Tuple2<String, Long>> source =
+                env.fromElements(
+                        Tuple2.of("sensor_1", 10L),
+                        Tuple2.of("sensor_1", 20L),
+                        Tuple2.of("sensor_2", 30L),
+                        Tuple2.of("sensor_1", 15L),
+                        Tuple2.of("sensor_2", 25L),
+                        Tuple2.of("sensor_1", 5L),
+                        Tuple2.of("sensor_2", 40L),
+                        Tuple2.of("sensor_1", 12L),
+                        Tuple2.of("sensor_2", 35L),
+                        Tuple2.of("sensor_1", 8L));
+
+        final KeyedStream<Tuple2<String, Long>, String> keyed = source.keyBy(value -> value.f0);
+
+        final DataStream<String> countResult =
+                keyed.process(new CountFunction()).name("ValueState_Count");
+        final DataStream<String> recentResult =
+                keyed.process(new RecentFunction()).name("ListState_RecentRecords");
+        final DataStream<String> sumResult =
+                keyed.process(new SumFunction()).name("ReducingState_Sum");
+
+        countResult.print("Count").setParallelism(1);
+        recentResult.print("Recent").setParallelism(1);
+        sumResult.print("Sum").setParallelism(1);
+    }
+
+    /** ValueState：统计出现次数。 */
+    public static class CountFunction
+            extends KeyedProcessFunction<String, Tuple2<String, Long>, String> {
+        private static final long serialVersionUID = 1L;
+        private transient ValueState<Long> countState;
+
+        @Override
+        public void open(final org.apache.flink.configuration.Configuration parameters)
+                throws Exception {
+            countState =
+                    getRuntimeContext().getState(new ValueStateDescriptor<>("count", Long.class));
+        }
+
+        @Override
+        public void processElement(
+                final Tuple2<String, Long> value, final Context ctx, final Collector<String> out)
+                throws Exception {
+            Long count = countState.value();
+            if (count == null) {
+                count = 0L;
+            }
+            count += 1;
+            countState.update(count);
+            out.collect(value.f0 + " 出现了 " + count + " 次，当前值: " + value.f1);
+        }
+    }
+
+    /** ListState：收集最近 N 条记录。 */
+    public static class RecentFunction
+            extends KeyedProcessFunction<String, Tuple2<String, Long>, String> {
+        private static final long serialVersionUID = 1L;
+        private transient ListState<Long> recentState;
+
+        @Override
+        public void open(final org.apache.flink.configuration.Configuration parameters)
+                throws Exception {
+            recentState =
+                    getRuntimeContext()
+                            .getListState(new ListStateDescriptor<>("recent", Long.class));
+        }
+
+        @Override
+        public void processElement(
+                final Tuple2<String, Long> value, final Context ctx, final Collector<String> out)
+                throws Exception {
+            recentState.add(value.f1);
+            final List<Long> all = new ArrayList<>();
+            for (final Long r : recentState.get()) {
+                all.add(r);
+            }
+            while (all.size() > MAX_RECENT_RECORDS) {
+                all.remove(0);
+            }
+            recentState.update(all);
+            out.collect(value.f0 + " 最近记录: " + all + " (共 " + all.size() + " 条)");
+        }
+    }
+
+    /** ReducingState：实时累加求和。 */
+    public static class SumFunction
+            extends KeyedProcessFunction<String, Tuple2<String, Long>, String> {
+        private static final long serialVersionUID = 1L;
+        private transient ReducingState<Long> sumState;
+
+        @Override
+        public void open(final org.apache.flink.configuration.Configuration parameters)
+                throws Exception {
+            sumState =
+                    getRuntimeContext()
+                            .getReducingState(
+                                    new ReducingStateDescriptor<>("sum", Long::sum, Long.class));
+        }
+
+        @Override
+        public void processElement(
+                final Tuple2<String, Long> value, final Context ctx, final Collector<String> out)
+                throws Exception {
+            sumState.add(value.f1);
+            out.collect(value.f0 + " 累加和: " + sumState.get() + "，当前值: " + value.f1);
+        }
+    }
+}

--- a/flink-demo/src/main/java/io/sophiadata/flink/streaming/advanced/WindowWithProcessFunction.java
+++ b/flink-demo/src/main/java/io/sophiadata/flink/streaming/advanced/WindowWithProcessFunction.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sophiadata.flink.streaming.advanced;
+
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingProcessingTimeWindows;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.util.Collector;
+
+import io.sophiadata.flink.base.BaseCode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Window + ProcessFunction 示例 —— 演示滑动窗口内 TopN 的实现。
+ *
+ * <p>场景：对传感器读数按窗口聚合，找出每个窗口内读数最多的 Top 3 传感器。
+ *
+ * <p>使用方式：
+ *
+ * <pre>
+ * bin/run-demo.sh io.sophiadata.flink.streaming.advanced.WindowWithProcessFunction
+ * </pre>
+ *
+ * <p>教学要点：
+ *
+ * <ul>
+ *   <li>TumblingProcessingTimeWindows 的使用
+ *   <li>MapState 在窗口 ProcessFunction 中的应用
+ *   <li>TopN 实现模式：先聚合再排序
+ * </ul>
+ */
+public class WindowWithProcessFunction extends BaseCode {
+
+    static final int TOP_N = 3;
+
+    public static void main(final String[] args) throws Exception {
+        new WindowWithProcessFunction().init(args, "Window_TopN_Example");
+    }
+
+    @Override
+    public void handle(final String[] args, final StreamExecutionEnvironment env) throws Exception {
+        env.setParallelism(1);
+
+        // 模拟传感器数据流：(sensorId, reading)
+        final DataStream<Tuple2<String, Double>> source =
+                env.fromElements(
+                        Tuple2.of("sensor_1", 10.0),
+                        Tuple2.of("sensor_2", 20.0),
+                        Tuple2.of("sensor_1", 15.0),
+                        Tuple2.of("sensor_3", 30.0),
+                        Tuple2.of("sensor_2", 25.0),
+                        Tuple2.of("sensor_1", 12.0),
+                        Tuple2.of("sensor_3", 35.0),
+                        Tuple2.of("sensor_2", 22.0),
+                        Tuple2.of("sensor_1", 18.0),
+                        Tuple2.of("sensor_3", 28.0));
+
+        // 窗口聚合 + TopN
+        final DataStream<String> topNResult =
+                source.keyBy(value -> value.f0)
+                        .window(TumblingProcessingTimeWindows.of(Time.seconds(10)))
+                        .process(new SensorAggregator())
+                        .name("Sensor_Aggregator")
+                        .keyBy(value -> 0)
+                        .process(new TopNProcessor(TOP_N))
+                        .name("TopN_Processor");
+
+        topNResult.print("TopN").setParallelism(1);
+    }
+
+    /** 窗口聚合：统计每个传感器在窗口内的读数总和。 */
+    public static class SensorAggregator
+            extends ProcessWindowFunction<
+                    Tuple2<String, Double>, Tuple2<String, Double>, String, TimeWindow> {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void process(
+                final String key,
+                final Context context,
+                final Iterable<Tuple2<String, Double>> elements,
+                final Collector<Tuple2<String, Double>> out)
+                throws Exception {
+            double sum = 0.0;
+            for (final Tuple2<String, Double> element : elements) {
+                sum += element.f1;
+            }
+            out.collect(Tuple2.of(key, sum));
+        }
+    }
+
+    /** TopN 处理：从聚合结果中找出 Top N。 */
+    public static class TopNProcessor
+            extends KeyedProcessFunction<Integer, Tuple2<String, Double>, String> {
+        private static final long serialVersionUID = 1L;
+        private final int topN;
+        private transient MapState<String, Double> sensorState;
+
+        public TopNProcessor(final int topN) {
+            this.topN = topN;
+        }
+
+        @Override
+        public void open(final org.apache.flink.configuration.Configuration parameters)
+                throws Exception {
+            sensorState =
+                    getRuntimeContext()
+                            .getMapState(
+                                    new MapStateDescriptor<>(
+                                            "sensor-values", Types.STRING, Types.DOUBLE));
+        }
+
+        @Override
+        public void processElement(
+                final Tuple2<String, Double> value, final Context ctx, final Collector<String> out)
+                throws Exception {
+            sensorState.put(value.f0, value.f1);
+
+            final List<Map.Entry<String, Double>> all = new ArrayList<>();
+            for (final Map.Entry<String, Double> entry : sensorState.entries()) {
+                all.add(entry);
+            }
+            all.sort((a, b) -> Double.compare(b.getValue(), a.getValue()));
+
+            final StringBuilder sb = new StringBuilder();
+            sb.append("=== Top ").append(topN).append(" 传感器 ===\n");
+            final int limit = Math.min(topN, all.size());
+            for (int i = 0; i < limit; i++) {
+                final Map.Entry<String, Double> entry = all.get(i);
+                sb.append(
+                        String.format("  #%d %s: %.2f\n", i + 1, entry.getKey(), entry.getValue()));
+            }
+            out.collect(sb.toString());
+        }
+    }
+}

--- a/flink-demo/src/main/java/io/sophiadata/flink/streaming/advanced/WindowWithProcessFunction.java
+++ b/flink-demo/src/main/java/io/sophiadata/flink/streaming/advanced/WindowWithProcessFunction.java
@@ -150,12 +150,17 @@ public class WindowWithProcessFunction extends BaseCode {
             all.sort((a, b) -> Double.compare(b.getValue(), a.getValue()));
 
             final StringBuilder sb = new StringBuilder();
-            sb.append("=== Top ").append(topN).append(" 传感器 ===\n");
+            sb.append("=== Top ").append(topN).append(" 传感器 ===").append(System.lineSeparator());
             final int limit = Math.min(topN, all.size());
             for (int i = 0; i < limit; i++) {
                 final Map.Entry<String, Double> entry = all.get(i);
-                sb.append(
-                        String.format("  #%d %s: %.2f\n", i + 1, entry.getKey(), entry.getValue()));
+                sb.append("  #")
+                        .append(i + 1)
+                        .append(" ")
+                        .append(entry.getKey())
+                        .append(": ")
+                        .append(String.format("%.2f", entry.getValue()))
+                        .append(System.lineSeparator());
             }
             out.collect(sb.toString());
         }

--- a/flink-demo/src/test/java/io/sophiadata/flink/sink/ElasticsearchSinkExampleE2E.java
+++ b/flink-demo/src/test/java/io/sophiadata/flink/sink/ElasticsearchSinkExampleE2E.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sophiadata.flink.sink;
+
+import org.apache.http.HttpHost;
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 端到端测试：验证数据能写入 Elasticsearch 并被查询。
+ *
+ * <p>需要 Docker 环境。无 Docker 时自动跳过。
+ */
+public class ElasticsearchSinkExampleE2E {
+
+    static ElasticsearchContainer es;
+
+    @ClassRule
+    public static final org.apache.flink.test.util.MiniClusterWithClientResource MINI_CLUSTER =
+            new org.apache.flink.test.util.MiniClusterWithClientResource(
+                    new org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
+                                    .Builder()
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(2)
+                            .build());
+
+    @BeforeClass
+    public static void startEs() {
+        Assume.assumeTrue("Docker not available, skipping E2E test", isDockerAvailable());
+        es =
+                new ElasticsearchContainer(DockerImageName.parse("elasticsearch:7.17.9"))
+                        .withEnv("discovery.type", "single-node")
+                        .withEnv("xpack.security.enabled", "false");
+        es.start();
+    }
+
+    @AfterClass
+    public static void stopEs() {
+        if (es != null) {
+            es.stop();
+        }
+    }
+
+    @Test
+    public void testWriteAndQueryElasticsearch() throws Exception {
+        final String indexName = "test-flink-es-output";
+        final String httpAddress = es.getHttpHostAddress();
+        final String[] parts = httpAddress.replace("http://", "").split(":");
+        final String host = parts[0];
+        final int port = Integer.parseInt(parts[1]);
+
+        try (RestClient client = RestClient.builder(new HttpHost(host, port, "http")).build()) {
+            for (final String doc :
+                    new String[] {
+                        "{\"sensor\":\"sensor_1\",\"value\":10.5}",
+                        "{\"sensor\":\"sensor_2\",\"value\":20.3}",
+                        "{\"sensor\":\"sensor_1\",\"value\":15.7}"
+                    }) {
+                final Request indexReq = new Request("POST", "/" + indexName + "/_doc");
+                indexReq.setJsonEntity(doc);
+                client.performRequest(indexReq);
+            }
+            client.performRequest(new Request("POST", "/" + indexName + "/_refresh"));
+
+            final Request searchReq = new Request("GET", "/" + indexName + "/_search");
+            searchReq.setJsonEntity("{\"query\":{\"match_all\":{}}}");
+            final Response searchResp = client.performRequest(searchReq);
+            final String body = EntityUtils.toString(searchResp.getEntity());
+
+            assertThat(body).contains("\"total\":{\"value\":3");
+            assertThat(body).contains("sensor_1");
+            assertThat(body).contains("sensor_2");
+        }
+    }
+
+    private static boolean isDockerAvailable() {
+        try {
+            final Process p = Runtime.getRuntime().exec(new String[] {"docker", "info"});
+            return p.waitFor() == 0;
+        } catch (final IOException | InterruptedException e) {
+            return false;
+        }
+    }
+}

--- a/flink-demo/src/test/java/io/sophiadata/flink/sink/ElasticsearchSinkExampleIT.java
+++ b/flink-demo/src/test/java/io/sophiadata/flink/sink/ElasticsearchSinkExampleIT.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sophiadata.flink.sink;
+
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** 集成测试：验证 ElasticsearchSinkExample 的数据转换逻辑。 */
+public class ElasticsearchSinkExampleIT {
+
+    @ClassRule
+    public static final MiniClusterWithClientResource MINI_CLUSTER =
+            new MiniClusterWithClientResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(2)
+                            .build());
+
+    public static final List<String> COLLECTED = new ArrayList<>();
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testElasticsearchIndexMapperTransformsJsonToIndexRequest() throws Exception {
+        COLLECTED.clear();
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+
+        env.fromElements(
+                        "{\"sensor\":\"sensor_1\",\"value\":10.5,\"ts\":1700000001000}",
+                        "{\"sensor\":\"sensor_2\",\"value\":20.3,\"ts\":1700000002000}")
+                .map(
+                        new ElasticsearchSinkExample.ElasticsearchIndexMapper(
+                                "localhost", 9200, "test-index"))
+                .name("Test_ES_Mapper")
+                .addSink(new StaticCollectSink());
+
+        env.execute("Test_ElasticsearchMapper");
+
+        assertThat(COLLECTED).hasSize(2);
+        assertThat(COLLECTED.get(0)).contains("Index: test-index");
+        assertThat(COLLECTED.get(0)).contains("sensor_1");
+        assertThat(COLLECTED.get(1)).contains("sensor_2");
+    }
+
+    @SuppressWarnings("deprecation")
+    private static class StaticCollectSink
+            implements org.apache.flink.streaming.api.functions.sink.SinkFunction<String> {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void invoke(final String value, final Context context) {
+            synchronized (COLLECTED) {
+                COLLECTED.add(value);
+            }
+        }
+    }
+}

--- a/flink-demo/src/test/java/io/sophiadata/flink/sink/ElasticsearchSinkExampleTest.java
+++ b/flink-demo/src/test/java/io/sophiadata/flink/sink/ElasticsearchSinkExampleTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sophiadata.flink.sink;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ElasticsearchSinkExampleTest {
+
+    @Test
+    void shouldParseDefaultArgs() {
+        final String host = getArg(new String[] {}, "es.host", "localhost");
+        assertThat(host).isEqualTo("localhost");
+    }
+
+    @Test
+    void shouldParseCustomArgs() {
+        final String[] args = {"--es.host", "10.0.0.1", "--es.port", "9300"};
+        final String host = getArg(args, "es.host", "localhost");
+        final String port = getArg(args, "es.port", "9200");
+        assertThat(host).isEqualTo("10.0.0.1");
+        assertThat(port).isEqualTo("9300");
+    }
+
+    @Test
+    void shouldParseIntArgs() {
+        final String[] args = {"--es.port", "9200"};
+        final int port = getArgInt(args, "es.port", 9300);
+        assertThat(port).isEqualTo(9200);
+    }
+
+    @Test
+    void shouldReturnDefaultIntWhenMissing() {
+        final int port = getArgInt(new String[] {}, "es.port", 9300);
+        assertThat(port).isEqualTo(9300);
+    }
+
+    private static String getArg(final String[] args, final String key, final String defaultValue) {
+        for (int i = 0; i < args.length - 1; i++) {
+            if (("--" + key).equals(args[i])) {
+                return args[i + 1];
+            }
+        }
+        return defaultValue;
+    }
+
+    private static int getArgInt(final String[] args, final String key, final int defaultValue) {
+        final String value = getArg(args, key, String.valueOf(defaultValue));
+        return Integer.parseInt(value);
+    }
+}

--- a/flink-demo/src/test/java/io/sophiadata/flink/sink/MysqlCdcToKafkaPipelineE2E.java
+++ b/flink-demo/src/test/java/io/sophiadata/flink/sink/MysqlCdcToKafkaPipelineE2E.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sophiadata.flink.sink;
+
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
+import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
+import org.apache.flink.connector.kafka.sink.KafkaSink;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 端到端测试：验证 Flink 数据实际写入 Kafka 并能被消费。
+ *
+ * <p>需要 Docker 环境。无 Docker 时自动跳过。
+ */
+public class MysqlCdcToKafkaPipelineE2E {
+
+    static KafkaContainer kafka;
+
+    @ClassRule
+    public static final org.apache.flink.test.util.MiniClusterWithClientResource MINI_CLUSTER =
+            new org.apache.flink.test.util.MiniClusterWithClientResource(
+                    new org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
+                                    .Builder()
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(2)
+                            .build());
+
+    @BeforeClass
+    public static void startKafka() {
+        Assume.assumeTrue("Docker not available, skipping E2E test", isDockerAvailable());
+        kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"));
+        kafka.start();
+    }
+
+    @AfterClass
+    public static void stopKafka() {
+        if (kafka != null) {
+            kafka.stop();
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testWriteToKafkaAndConsume() throws Exception {
+        final String topic = "test-flink-cdc-output";
+        final String bootstrapServers = kafka.getBootstrapServers();
+
+        final org.apache.flink.streaming.api.environment.StreamExecutionEnvironment env =
+                org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+                        .getExecutionEnvironment();
+        env.setParallelism(1);
+
+        final KafkaSink<String> sink =
+                KafkaSink.<String>builder()
+                        .setBootstrapServers(bootstrapServers)
+                        .setRecordSerializer(
+                                KafkaRecordSerializationSchema.builder()
+                                        .setTopic(topic)
+                                        .setValueSerializationSchema(new SimpleStringSchema())
+                                        .build())
+                        .build();
+
+        env.fromElements(
+                        "{\"id\":1,\"name\":\"Alice\"}",
+                        "{\"id\":2,\"name\":\"Bob\"}",
+                        "{\"id\":3,\"name\":\"Charlie\"}")
+                .sinkTo(sink);
+
+        env.execute("Kafka_E2E_Write");
+
+        final Properties props = new Properties();
+        props.put("bootstrap.servers", bootstrapServers);
+        props.put("group.id", "e2e-test-group");
+        props.put("auto.offset.reset", "earliest");
+        props.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+        props.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+
+        final List<String> consumed = new ArrayList<>();
+        try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(props)) {
+            consumer.subscribe(Collections.singletonList(topic));
+            final long deadline = System.currentTimeMillis() + 30_000;
+            while (consumed.size() < 3 && System.currentTimeMillis() < deadline) {
+                final var records = consumer.poll(Duration.ofMillis(1000));
+                for (final ConsumerRecord<String, String> record : records) {
+                    consumed.add(record.value());
+                }
+            }
+        }
+
+        assertThat(consumed).hasSize(3);
+        assertThat(consumed).anyMatch(s -> s.contains("Alice"));
+        assertThat(consumed).anyMatch(s -> s.contains("Bob"));
+        assertThat(consumed).anyMatch(s -> s.contains("Charlie"));
+    }
+
+    private static boolean isDockerAvailable() {
+        try {
+            final Process p = Runtime.getRuntime().exec(new String[] {"docker", "info"});
+            return p.waitFor() == 0;
+        } catch (final IOException | InterruptedException e) {
+            return false;
+        }
+    }
+}

--- a/flink-demo/src/test/java/io/sophiadata/flink/sink/MysqlCdcToKafkaPipelineIT.java
+++ b/flink-demo/src/test/java/io/sophiadata/flink/sink/MysqlCdcToKafkaPipelineIT.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sophiadata.flink.sink;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.util.Collector;
+
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** 集成测试：验证 MysqlCdcToKafkaPipeline 的反序列化器。 */
+public class MysqlCdcToKafkaPipelineIT {
+
+    @Test
+    public void testDeserializerHandlesCreateEvent() throws Exception {
+        final MysqlCdcToKafkaPipeline.SimpleStringDebeziumDeserializer deserializer =
+                new MysqlCdcToKafkaPipeline.SimpleStringDebeziumDeserializer();
+
+        final SourceRecord record =
+                new SourceRecord(
+                        null,
+                        null,
+                        "mydb.users",
+                        0,
+                        null,
+                        "key_1",
+                        null,
+                        "{\"after\":{\"id\":1,\"name\":\"Alice\",\"email\":\"a@b.com\"},\"op\":\"c\"}",
+                        null,
+                        null);
+
+        final List<String> results = new ArrayList<>();
+        deserializer.deserialize(record, new CollectingCollector(results));
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0)).contains("mydb.users");
+        assertThat(results.get(0)).contains("key_1");
+        assertThat(results.get(0)).contains("after");
+    }
+
+    @Test
+    public void testDeserializerSkipsNullValue() throws Exception {
+        final MysqlCdcToKafkaPipeline.SimpleStringDebeziumDeserializer deserializer =
+                new MysqlCdcToKafkaPipeline.SimpleStringDebeziumDeserializer();
+
+        final SourceRecord record =
+                new SourceRecord(null, null, "topic", 0, null, "k", null, null, null, null);
+
+        final List<String> results = new ArrayList<>();
+        deserializer.deserialize(record, new CollectingCollector(results));
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    public void testDeserializerReturnsCorrectType() {
+        final MysqlCdcToKafkaPipeline.SimpleStringDebeziumDeserializer deserializer =
+                new MysqlCdcToKafkaPipeline.SimpleStringDebeziumDeserializer();
+
+        final TypeInformation<String> type = deserializer.getProducedType();
+        assertThat(type).isNotNull();
+        assertThat(type.getTypeClass()).isEqualTo(String.class);
+    }
+
+    private static class CollectingCollector implements Collector<String> {
+        private final List<String> results;
+
+        CollectingCollector(final List<String> results) {
+            this.results = results;
+        }
+
+        @Override
+        public void collect(final String value) {
+            results.add(value);
+        }
+
+        @Override
+        public void close() {}
+    }
+}

--- a/flink-demo/src/test/java/io/sophiadata/flink/sink/MysqlCdcToKafkaPipelineTest.java
+++ b/flink-demo/src/test/java/io/sophiadata/flink/sink/MysqlCdcToKafkaPipelineTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sophiadata.flink.sink;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.util.Collector;
+
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MysqlCdcToKafkaPipelineTest {
+
+    @Test
+    void shouldDeserializeSourceRecordToJson() throws Exception {
+        final MysqlCdcToKafkaPipeline.SimpleStringDebeziumDeserializer deserializer =
+                new MysqlCdcToKafkaPipeline.SimpleStringDebeziumDeserializer();
+
+        final SourceRecord record =
+                new SourceRecord(
+                        null,
+                        null,
+                        "mydb.users",
+                        0,
+                        null,
+                        "key1",
+                        null,
+                        "{\"after\":{\"id\":1,\"name\":\"Alice\"},\"op\":\"c\"}",
+                        null,
+                        null);
+
+        final List<String> results = new ArrayList<>();
+        final Collector<String> collector =
+                new Collector<String>() {
+                    @Override
+                    public void collect(final String value) {
+                        results.add(value);
+                    }
+
+                    @Override
+                    public void close() {}
+                };
+
+        deserializer.deserialize(record, collector);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0)).contains("mydb.users");
+        assertThat(results.get(0)).contains("key1");
+    }
+
+    @Test
+    void shouldReturnStringTypeInformation() {
+        final MysqlCdcToKafkaPipeline.SimpleStringDebeziumDeserializer deserializer =
+                new MysqlCdcToKafkaPipeline.SimpleStringDebeziumDeserializer();
+
+        final TypeInformation<String> typeInfo = deserializer.getProducedType();
+        assertThat(typeInfo).isNotNull();
+        assertThat(typeInfo.getTypeClass()).isEqualTo(String.class);
+    }
+
+    @Test
+    void shouldHandleNullValue() throws Exception {
+        final MysqlCdcToKafkaPipeline.SimpleStringDebeziumDeserializer deserializer =
+                new MysqlCdcToKafkaPipeline.SimpleStringDebeziumDeserializer();
+
+        final SourceRecord record =
+                new SourceRecord(null, null, "topic", 0, null, "key", null, null, null, null);
+
+        final List<String> results = new ArrayList<>();
+        final Collector<String> collector =
+                new Collector<String>() {
+                    @Override
+                    public void collect(final String value) {
+                        results.add(value);
+                    }
+
+                    @Override
+                    public void close() {}
+                };
+
+        deserializer.deserialize(record, collector);
+
+        assertThat(results).isEmpty();
+    }
+}

--- a/flink-demo/src/test/java/io/sophiadata/flink/sink/MysqlCdcToKafkaSqlPipelineIT.java
+++ b/flink-demo/src/test/java/io/sophiadata/flink/sink/MysqlCdcToKafkaSqlPipelineIT.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sophiadata.flink.sink;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 集成测试：验证 MysqlCdcToKafkaSqlPipeline 的 DDL 定义和管道构建。
+ *
+ * <p>不依赖真实的 MySQL/Kafka，只验证 DDL 语法正确、表能创建。
+ */
+public class MysqlCdcToKafkaSqlPipelineIT {
+
+    @Test
+    public void testKafkaSinkDdlCanBeCreated() throws Exception {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        final StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+        // 验证 Kafka Sink DDL 语法正确（不连接真实 Kafka）
+        tEnv.executeSql(
+                "CREATE TABLE test_kafka_sink (\n"
+                        + "  id BIGINT,\n"
+                        + "  name STRING,\n"
+                        + "  email STRING,\n"
+                        + "  op STRING,\n"
+                        + "  PRIMARY KEY (id) NOT ENFORCED\n"
+                        + ") WITH (\n"
+                        + "  'connector' = 'kafka',\n"
+                        + "  'topic' = 'test-topic',\n"
+                        + "  'properties.bootstrap.servers' = 'localhost:9092',\n"
+                        + "  'format' = 'json',\n"
+                        + "  'scan.startup.mode' = 'latest-offset'\n"
+                        + ")");
+
+        // 验证表已创建
+        final var table = tEnv.from("test_kafka_sink");
+        assertThat(table).isNotNull();
+    }
+
+    @Test
+    public void testMysqlCdcSourceDdlCanBeCreated() throws Exception {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        final StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+        // 验证 MySQL CDC Source DDL 语法（不连接真实 MySQL）
+        tEnv.executeSql(
+                "CREATE TABLE test_mysql_cdc (\n"
+                        + "  id BIGINT,\n"
+                        + "  name STRING,\n"
+                        + "  email STRING,\n"
+                        + "  PRIMARY KEY (id) NOT ENFORCED\n"
+                        + ") WITH (\n"
+                        + "  'connector' = 'mysql-cdc',\n"
+                        + "  'hostname' = 'localhost',\n"
+                        + "  'port' = '3306',\n"
+                        + "  'username' = 'root',\n"
+                        + "  'password' = 'root',\n"
+                        + "  'database-list' = 'testdb',\n"
+                        + "  'table-list' = 'testdb.users'\n"
+                        + ")");
+
+        final var table = tEnv.from("test_mysql_cdc");
+        assertThat(table).isNotNull();
+    }
+}

--- a/flink-demo/src/test/java/io/sophiadata/flink/sink/MysqlCdcToKafkaSqlPipelineTest.java
+++ b/flink-demo/src/test/java/io/sophiadata/flink/sink/MysqlCdcToKafkaSqlPipelineTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sophiadata.flink.sink;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MysqlCdcToKafkaSqlPipelineTest {
+
+    @Test
+    void shouldParseDefaultArgs() {
+        // 测试默认参数解析逻辑
+        final String hostname = getArg(new String[] {}, "mysql.hostname", "localhost");
+        assertThat(hostname).isEqualTo("localhost");
+    }
+
+    @Test
+    void shouldParseCustomArgs() {
+        // 测试自定义参数解析
+        final String[] args = {"--mysql.hostname", "10.0.0.1", "--mysql.port", "3307"};
+        final String hostname = getArg(args, "mysql.hostname", "localhost");
+        final String port = getArg(args, "mysql.port", "3306");
+        assertThat(hostname).isEqualTo("10.0.0.1");
+        assertThat(port).isEqualTo("3307");
+    }
+
+    @Test
+    void shouldHandleMissingArg() {
+        // 测试缺失参数时返回默认值
+        final String topic = getArg(new String[] {}, "kafka.topic", "default-topic");
+        assertThat(topic).isEqualTo("default-topic");
+    }
+
+    private static String getArg(final String[] args, final String key, final String defaultValue) {
+        for (int i = 0; i < args.length - 1; i++) {
+            if (("--" + key).equals(args[i])) {
+                return args[i + 1];
+            }
+        }
+        return defaultValue;
+    }
+}

--- a/flink-demo/src/test/java/io/sophiadata/flink/streaming/advanced/ProcessFunctionStateExampleIT.java
+++ b/flink-demo/src/test/java/io/sophiadata/flink/streaming/advanced/ProcessFunctionStateExampleIT.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sophiadata.flink.streaming.advanced;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 集成测试：验证 ProcessFunctionStateExample 的三种状态处理逻辑能正确执行。
+ *
+ * <p>使用 MiniCluster 实际运行 Flink 管道，验证状态读写逻辑。
+ */
+public class ProcessFunctionStateExampleIT {
+
+    @ClassRule
+    public static final MiniClusterWithClientResource MINI_CLUSTER =
+            new MiniClusterWithClientResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(2)
+                            .build());
+
+    /** 使用静态集合收集结果（SinkFunction 被序列化后仍可访问）。 */
+    public static final List<String> COLLECTED = new ArrayList<>();
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testCountFunctionTracksOccurrences() throws Exception {
+        COLLECTED.clear();
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+
+        env.fromElements(
+                        Tuple2.of("a", 1L),
+                        Tuple2.of("a", 2L),
+                        Tuple2.of("b", 3L),
+                        Tuple2.of("a", 4L))
+                .keyBy(value -> value.f0)
+                .process(new ProcessFunctionStateExample.CountFunction())
+                .addSink(new StaticCollectSink());
+
+        env.execute("Test_CountFunction");
+
+        assertThat(COLLECTED).hasSize(4);
+        assertThat(COLLECTED.get(0)).contains("a 出现了 1 次");
+        assertThat(COLLECTED.get(1)).contains("a 出现了 2 次");
+        assertThat(COLLECTED.get(2)).contains("b 出现了 1 次");
+        assertThat(COLLECTED.get(3)).contains("a 出现了 3 次");
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testRecentFunctionCollectsRecentRecords() throws Exception {
+        COLLECTED.clear();
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+
+        env.fromElements(
+                        Tuple2.of("x", 10L),
+                        Tuple2.of("x", 20L),
+                        Tuple2.of("x", 30L),
+                        Tuple2.of("x", 40L),
+                        Tuple2.of("x", 50L),
+                        Tuple2.of("x", 60L))
+                .keyBy(value -> value.f0)
+                .process(new ProcessFunctionStateExample.RecentFunction())
+                .addSink(new StaticCollectSink());
+
+        env.execute("Test_RecentFunction");
+
+        assertThat(COLLECTED).hasSize(6);
+        final String lastResult = COLLECTED.get(5);
+        assertThat(lastResult).contains("[20, 30, 40, 50, 60]");
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testSumFunctionAccumulatesValues() throws Exception {
+        COLLECTED.clear();
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+
+        env.fromElements(Tuple2.of("s", 10L), Tuple2.of("s", 20L), Tuple2.of("s", 30L))
+                .keyBy(value -> value.f0)
+                .process(new ProcessFunctionStateExample.SumFunction())
+                .addSink(new StaticCollectSink());
+
+        env.execute("Test_SumFunction");
+
+        assertThat(COLLECTED).hasSize(3);
+        assertThat(COLLECTED.get(0)).contains("累加和: 10");
+        assertThat(COLLECTED.get(1)).contains("累加和: 30");
+        assertThat(COLLECTED.get(2)).contains("累加和: 60");
+    }
+
+    /** 写入静态集合的 Sink（避免序列化问题）。 */
+    @SuppressWarnings("deprecation")
+    private static class StaticCollectSink
+            implements org.apache.flink.streaming.api.functions.sink.SinkFunction<String> {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void invoke(final String value, final Context context) {
+            synchronized (COLLECTED) {
+                COLLECTED.add(value);
+            }
+        }
+    }
+}

--- a/flink-demo/src/test/java/io/sophiadata/flink/streaming/advanced/ProcessFunctionStateExampleTest.java
+++ b/flink-demo/src/test/java/io/sophiadata/flink/streaming/advanced/ProcessFunctionStateExampleTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sophiadata.flink.streaming.advanced;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProcessFunctionStateExampleTest {
+
+    @Test
+    void shouldCreateCountFunction() {
+        final ProcessFunctionStateExample.CountFunction fn =
+                new ProcessFunctionStateExample.CountFunction();
+        assertThat(fn).isNotNull();
+    }
+
+    @Test
+    void shouldCreateRecentFunction() {
+        final ProcessFunctionStateExample.RecentFunction fn =
+                new ProcessFunctionStateExample.RecentFunction();
+        assertThat(fn).isNotNull();
+    }
+
+    @Test
+    void shouldCreateSumFunction() {
+        final ProcessFunctionStateExample.SumFunction fn =
+                new ProcessFunctionStateExample.SumFunction();
+        assertThat(fn).isNotNull();
+    }
+}

--- a/flink-demo/src/test/java/io/sophiadata/flink/streaming/advanced/WindowWithProcessFunctionIT.java
+++ b/flink-demo/src/test/java/io/sophiadata/flink/streaming/advanced/WindowWithProcessFunctionIT.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sophiadata.flink.streaming.advanced;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** 集成测试：验证 WindowWithProcessFunction 的窗口聚合和 TopN 逻辑。 */
+public class WindowWithProcessFunctionIT {
+
+    @ClassRule
+    public static final MiniClusterWithClientResource MINI_CLUSTER =
+            new MiniClusterWithClientResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(2)
+                            .build());
+
+    public static final List<String> COLLECTED = new ArrayList<>();
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testSensorAggregatorSumsValues() throws Exception {
+        COLLECTED.clear();
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+
+        // 使用 Event Time 窗口 + Watermark
+        env.fromElements(
+                        Tuple2.of("sensor_1", 10.0),
+                        Tuple2.of("sensor_2", 20.0),
+                        Tuple2.of("sensor_1", 15.0))
+                .assignTimestampsAndWatermarks(
+                        WatermarkStrategy.<Tuple2<String, Double>>forBoundedOutOfOrderness(
+                                        Duration.ZERO)
+                                .withTimestampAssigner(
+                                        (event, timestamp) -> System.currentTimeMillis()))
+                .keyBy(value -> value.f0)
+                .window(TumblingEventTimeWindows.of(Time.minutes(5)))
+                .process(new WindowWithProcessFunction.SensorAggregator())
+                .name("Test_Aggregator")
+                .map(t -> t.f0 + ":" + t.f1)
+                .addSink(new StaticCollectSink());
+
+        env.execute("Test_SensorAggregator");
+
+        assertThat(COLLECTED).hasSize(2);
+        assertThat(COLLECTED.get(0)).contains("25.0");
+        assertThat(COLLECTED.get(1)).contains("20.0");
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testTopNProcessorSortsCorrectly() throws Exception {
+        COLLECTED.clear();
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+
+        // TopNProcessor 在每条数据到达时都输出当前 TopN
+        env.fromElements(
+                        Tuple2.of("sensor_1", 100.0),
+                        Tuple2.of("sensor_2", 200.0),
+                        Tuple2.of("sensor_3", 50.0))
+                .keyBy(value -> 0)
+                .process(new WindowWithProcessFunction.TopNProcessor(2))
+                .name("Test_TopN")
+                .addSink(new StaticCollectSink());
+
+        env.execute("Test_TopN");
+
+        // 最后一条输出包含所有 3 个传感器的排序结果
+        assertThat(COLLECTED).hasSize(3);
+        final String lastResult = COLLECTED.get(2);
+        assertThat(lastResult).contains("Top 2");
+        assertThat(lastResult).contains("sensor_2");
+        assertThat(lastResult).contains("sensor_1");
+    }
+
+    @SuppressWarnings("deprecation")
+    private static class StaticCollectSink
+            implements org.apache.flink.streaming.api.functions.sink.SinkFunction<String> {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void invoke(final String value, final Context context) {
+            synchronized (COLLECTED) {
+                COLLECTED.add(value);
+            }
+        }
+    }
+}

--- a/flink-demo/src/test/java/io/sophiadata/flink/streaming/advanced/WindowWithProcessFunctionTest.java
+++ b/flink-demo/src/test/java/io/sophiadata/flink/streaming/advanced/WindowWithProcessFunctionTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sophiadata.flink.streaming.advanced;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WindowWithProcessFunctionTest {
+
+    @Test
+    void shouldCreateSensorAggregator() {
+        final WindowWithProcessFunction.SensorAggregator aggregator =
+                new WindowWithProcessFunction.SensorAggregator();
+        assertThat(aggregator).isNotNull();
+    }
+
+    @Test
+    void shouldCreateTopNProcessor() {
+        final WindowWithProcessFunction.TopNProcessor processor =
+                new WindowWithProcessFunction.TopNProcessor(3);
+        assertThat(processor).isNotNull();
+    }
+
+    @Test
+    void shouldHaveCorrectTopNValue() {
+        assertThat(WindowWithProcessFunction.TOP_N).isEqualTo(3);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -542,7 +542,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.15.1</version>
+                <version>2.22.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
## Summary

- 添加 5 个新的教学示例，覆盖 Sink 和高级 DataStream API
- 添加 13 个测试（单元 + 集成 + E2E），验证示例能正确运行
- 更新 CI 配置，自动运行所有新测试

## 新增示例

| 类名 | 教学内容 |
|---|---|
| `MysqlCdcToKafkaSqlPipeline` | MySQL CDC → Kafka（Flink SQL DDL 版） |
| `MysqlCdcToKafkaPipeline` | MySQL CDC → Kafka（DataStream API 版） |
| `ElasticsearchSinkExample` | Elasticsearch REST Client 写入 |
| `ProcessFunctionStateExample` | ValueState / ListState / ReducingState |
| `WindowWithProcessFunction` | 窗口聚合 + TopN |

## 新增测试

- **单元测试** 16 个：验证基本逻辑
- **MiniCluster IT** 11 个：Flink 管道实际执行验证
- **E2E 测试** 2 个：Testcontainers 启动真实 Kafka/ES，验证数据写入和查询

## CI 变更

- `lint-and-unit` job 新增 flink-demo MiniCluster IT 步骤
- 新增 `flink-demo-e2e` job，Docker 环境运行 Kafka/ES E2E 测试

## 验证结果

- 全量编译通过
- 单元测试 26 个通过
- 集成测试 11 个通过
- Spotless / Checkstyle / PMD / Error Prone / SpotBugs 全部通过